### PR TITLE
Fix copy/paste error in page titles.

### DIFF
--- a/content/labs/_index.md
+++ b/content/labs/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Mitmachen
+title: OK Labs
 ---
 
 In unseren OK Labs verbinden wir Menschen mit ähnlichen Interessen aus ganz unterschiedlichen Bereichen. Gemeinsam arbeiten wir an Anwendungen und Visualisierungen, die Offene Daten befreien und so Informationen für alle Menschen zugänglich machen. Durch die Einbindung in das bundesweite Code for Germany Netzwerk streuen wir unsere Ergebnisse in unterschiedlichste Teile der Gesellschaft und verhelfen dem digitalen Ehrenamt zu noch mehr Sichtbarkeit.

--- a/content/mitmachen.md
+++ b/content/mitmachen.md
@@ -1,5 +1,5 @@
 ---
-title: Über Code for Germany
+title: Mitmachen
 menu: 
   main:
     weight: 20

--- a/content/ueber.md
+++ b/content/ueber.md
@@ -1,5 +1,5 @@
 ---
-title: Über Code for Germany
+title: Über uns
 menu:
   main:
     weight: 10

--- a/content/ziele.md
+++ b/content/ziele.md
@@ -1,5 +1,5 @@
 ---
-title: Über Code for Germany
+title: Unsere Ziele
 menu: 
   main:
     weight: 30


### PR DESCRIPTION
+ Several pages had `Über Code for Germany` as their page tile in browser status bar.