### PR TITLE
Tweak CSS for blog posts

### DIFF
--- a/themes/codefor-theme/assets/scss/breakpoints/_base.scss
+++ b/themes/codefor-theme/assets/scss/breakpoints/_base.scss
@@ -81,7 +81,7 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6{
     margin-bottom: 1rem;
   }
   p{
-    margin-bottom: 4rem;
+    margin-bottom: 2rem;
   }
 }
 

--- a/themes/codefor-theme/assets/scss/breakpoints/_base.scss
+++ b/themes/codefor-theme/assets/scss/breakpoints/_base.scss
@@ -72,7 +72,6 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6{
     margin-top: 50px;
     margin-bottom: 20px;
   }
-  
   h3{
     font-size: $fontSizeBase +4px;
     margin-top: 20px;
@@ -338,10 +337,10 @@ footer{
 }
 
 .circle-123-line{
-  position: absolute; 
+  position: absolute;
   border-top: 1px solid #000;
-  width: calc(100% - 33%); 
-  left: 16%; 
+  width: calc(100% - 33%);
+  left: 16%;
   top: 50%;
   z-index: -1;
 }
@@ -473,6 +472,6 @@ footer{
       }
     }
   }
-  
+
 }
 

--- a/themes/codefor-theme/assets/scss/breakpoints/_base.scss
+++ b/themes/codefor-theme/assets/scss/breakpoints/_base.scss
@@ -81,6 +81,9 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6{
   img{
     padding: 60px;
   }
+  p{
+    margin-bottom: 4rem;
+  }
 }
 
 
@@ -99,13 +102,6 @@ a.no-underline:hover{
 .no-text-transform{
   text-transform: none !important;
 }
-
-.freetext-container{
-  p{
-    margin-bottom: 4rem;
-  }
-}
-
 
 //---------------------------------------------------
 // links

--- a/themes/codefor-theme/assets/scss/breakpoints/_base.scss
+++ b/themes/codefor-theme/assets/scss/breakpoints/_base.scss
@@ -77,8 +77,8 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6{
     margin-top: 20px;
     margin-bottom: 10px;
   }
-  img{
-    padding: 60px;
+  img {
+    margin-bottom: 1rem;
   }
   p{
     margin-bottom: 4rem;


### PR DESCRIPTION
This PR
- Halfs the margin after a paragraph (from `4rem` to `2rem`)
- Removes the padding around images

I don't see why we should not display images (e.g. in blogposts) full width and thought that they looked weirdly small in the current implementation. The margin at the end of a paragraph was also so big that at times it was difficult to even tell that paragraphs belonged to the same section (see e.g. the last section in the screenshot above), so I reduced that.

Unfortunately, the `freetext-container` class is not only used in the blog but I don't think this has any negative consequences for other pages.

Here is an example for a still unpublished blogpost where I first noticed this:

| Before | After |
|--------|-------|
|    ![before](https://user-images.githubusercontent.com/1096357/102064376-83a86600-3df7-11eb-9168-516dcf1c6f45.png)|  ![Screenshot_2020-12-14 OK Lab Berlin - Rückblick auf unsere Vortragsreihe 2020 Code for Germany(2)](https://user-images.githubusercontent.com/1096357/102064156-447a1500-3df7-11eb-92f6-9eec4db4e4a0.png)   |