### PR TITLE
Add Matomo for analytics

### DIFF
--- a/content/datenschutz.md
+++ b/content/datenschutz.md
@@ -119,26 +119,20 @@ Datenschutzerklärung
 
 <h3>VIII. Internetspezifische Datenverarbeitungen</h3>
 
-<!--
-<p>1. "Matomo": Während der Nutzung unserer Internetseiten werden durch uns automatisch technische Zugriffsdaten aufgezeichnet und ausgewertet. Hierfür benutzen wir das Tool "Matomo" (ehemals „Piwik“), ein Open-Source-Programm für Webanalytik, welches statistische Kennwerte zur Nutzung unserer Website auswertet. Diese Daten können jedoch nicht einer bestimmten Person zugeordnet werden; der einzelne Benutzer bleibt hierbei anonym. Weitere Informationen zu "Matomo" finden Sie auf der Website
-	<a href="https://matomo.org">https://matomo.org</a>.</p>
+<p>1. Matomo: Während der Nutzung unserer Internetseiten werden durch uns automatisch technische Zugriffsdaten aufgezeichnet und ausgewertet. Hierfür benutzen wir das Tool “Matomo” (ehemals „Piwik“), ein Open-Source-Programm für Webanalytik, welches statistische Kennwerte zur Nutzung unserer Website auswertet. Diese Daten können jedoch nicht einer bestimmten Person zugeordnet werden; der einzelne Benutzer bleibt hierbei anonym. Weitere Informationen zu “Matomo” finden Sie auf der Website <a href="https://matomo.org">https://matomo.org</a>.</p>
 <p>Zu diesen Daten gehören zum Beispiel</p>
 <ul>
-	<li>Die um die letzten beiden Oktette gekürzte IP-Adresse,</li>
-	<li>Informationen über den verwendeten Internet-Browser und das verwendete Betriebssystem,</li>
-	<li>der Domain-Name der Website, von der aus ein Besuch unserer Internet-Seiten erfolgt,</li>
-	<li>die durchschnittliche Verweildauer in unserem Angebot und</li>
-	<li>die in unserer Web-Site aufgerufenen Seiten.</li>
+    <li>Die um die letzten beiden Oktette gekürzte IP-Adresse,</li>
+    <li>Informationen über den verwendeten Internet-Browser und das verwendete Betriebssystem,</li>
+    <li>der Domain-Name der Website, von der aus ein Besuch unserer Internet-Seiten erfolgt,</li>
+    <li>die durchschnittliche Verweildauer in unserem Angebot und</li>
+    <li>die in unserer Web-Site aufgerufenen Seiten.</li>
 </ul>
-<p>Für die Nutzung von Matomo verwenden wir sogenannte „Cookies“. Hierbei handelt es sich um kleine Textdateien, die ein Webserver an ihren Computer senden kann, um diesen für die Dauer des Besuches zu identifizieren. Wir setzen die beiden Session Cookies pk_ses sowie die persistenten Cookies pk_id und pk_ref ein. Über diese Cookies erfassen wir keine personenbezogenen Daten von Ihnen.</p
-<p>pk_ses wird grundsätzlich nach dem Beenden Ihrer Browsersitzung gelöscht, lediglich bei pk_id und pk_ref handelt es sich um ein über eine Browsersitzung hinaus bestehendes (sog. persistentes) Cookie, anhand dessen wir erkennen können, wann ein Nutzer unsere Seite erneut besucht. Sofern Sie das Cookie nicht selbst entfernen, löscht es sich nach 1 Jahr bzw. 6 Monaten selbständig.</p
-<p>Die Darstellung unserer Internetseite ist auch ohne Speicherung von Cookies möglich. Sie können das Speichern von Cookies in den Einstellungen ihres Browsers deaktivieren oder diesen so einstellen, dass er Sie über die beabsichtigte Speicherung durch eine Internetseite informiert. In diesem Fall entscheiden Sie über die Annahme des Cookies.</p>
-<p>Zudem können durch die Entfernung des folgenden Hakens verhindern, dass wir mittels Matomo Analyse-Cookies auf Ihrem Endgerät setzen. In diesem Fall wird ein Cookie gesetzt um uns zu signalisieren, dass Sie der Nutzung widersprochen haben.</p>
+<p>Durch die Entfernung des folgenden <a href="https://traffic.okfn.de/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=de">Hakens</a> können Sie verhindern, dass wir mittels Matomo Ihre Besuche zählen. In diesem Fall wird ein Cookie gesetzt um uns zu signalisieren, dass Sie der Nutzung widersprochen haben.</p>
 <p>Bitte beachten Sie, dass die jeweiligen Einstellungen bzgl. Cookies nur für Ihr aktuell benutztes Gerät und Ihren aktuell benutzten Browser wirksam sind. Sollten Sie ein anderes Gerät oder einen anderen Browser benutzen, müssen Sie in der Regel die Einstellungen erneut vornehmen. Zudem unterstützen wir die „Do not Track“ Funktion Ihres Browsers. Hiermit können Sie uns aktiv über Ihre Browsereinstellungen mitteilen, ob Sie eine Aufzeichnung Ihrer Aktivitäten wünschen oder nicht. Haben Sie „Do not Track“ aktiviert, erfolgt keine Aufzeichnung Ihrer Aktivitäten.</p>
-<p>Die Rechtsgrundlage für die Verwendung von Matomo findet sich in Art. 6 Abs. 1 lit. f) DS-GVO. Unser berechtigtes Interesse besteht darin, dass wir die Nutzung unserer Website zu deren Verbesserung und Optimierung auswerten. Die so erfassten Daten werden für einen Zeitraum von 24 Monaten gespeichert.</p> 
--->
+<p>Die Rechtsgrundlage für die Verwendung von Matomo findet sich in Art. 6 Abs. 1 lit. f) DS-GVO. Unser berechtigtes Interesse besteht darin, dass wir die Nutzung unserer Website zu deren Verbesserung und Optimierung auswerten. Die so erfassten Daten werden für einen Zeitraum von 24 Monaten gespeichert.</p>
 
-<p>1. Einbindung von Youtube Videos: Wir haben YouTube-Videos in unser Online-Angebot eingebunden.YouTube ist ein Broadcasting-Dienst, der uns das kostenlose Einstellen und Verlinken von Videoclips zur Darstellung unseres Unternehmens ermöglicht. Der Dienst auf 
+<p>2. Einbindung von Youtube Videos: Wir haben YouTube-Videos in unser Online-Angebot eingebunden.YouTube ist ein Broadcasting-Dienst, der uns das kostenlose Einstellen und Verlinken von Videoclips zur Darstellung unseres Unternehmens ermöglicht. Der Dienst auf 
 	<a href="https://www.youtube.com/?gl=DE">youtube.com</a>
 wird bereitgestellt von der Google Ireland Limited, Gordon House, Barrow Street, Dublin 4, Irland („Google“).</p>
 	
@@ -154,7 +148,7 @@ von Google. Dort erhalten Sie auch weitere Informationen zu Ihren Rechten und Ei
 	<a href="https://www.privacyshield.gov/EU-US-Framework">US-Privacy-Shield</a>
 unterworfen.</p>
 
-<p>2. Einbindung von Twitter: Weiter ist der Tweet-Button von 
+<p>3. Einbindung von Twitter: Weiter ist der Tweet-Button von 
 	<a href="https://twitter.com">twitter.com</a>
 implementiert, für welchen das Unternehmen Twitter Inc., 795 Folsom St., Suite 600, San Francisco, CA 94107 in den USA verantwortlich zeichnet (im Folgenden „Twitter“). Der Button ist an einem weißem “t“ oder an einem Vogel erkennbar. Wenn Sie einen Teil unserer Webseite aufrufen, der eine solche Schaltfläche enthält, baut der Browser bei einer Aktivierung eine direkte Verbindung mit den Servern von Twitter auf. Auch Twitter nutzt Cookies. Jedenfalls erhebt Twitter Daten über Ihr Nutzungsverhalten. Wir haben keinen Einfluss auf den Umfang der Daten, die Twitter mit der Schaltfläche erhebt.</p>
 

--- a/content/datenschutz.md
+++ b/content/datenschutz.md
@@ -158,13 +158,6 @@ implementiert, für welchen das Unternehmen Twitter Inc., 795 Folsom St., Suite 
 
 <p>Weitere Ausführungen finden Sie in der
 	<a href="https://twitter.com/de/privacy">Datenschutzerklärung von Twitter</a>.</p>
-	
-<p>3. "Mapbox": Die Kartenbilder auf der Webseite werden von Mapbox, Inc., 740 15th Street NW, 5th Floor, Washington DC 20005 gehostet (“Mapbox”). Bei Anfragen über die APIs von Mapbox werden automatisch bestimmte technische Informationen, einschließlich (a) IP-Adresse, (b) Geräte- und Browserinformationen, (c) Betriebssystem, (d) Inhalt der Anfrage, (e) Datum und Uhrzeit der Anfrage und (f) begrenzte Standort- und Nutzungsdaten, erfasst. Sie löschen IP-Adressen nach 30 Tagen. Wenn eine mobile Anwendung ihre SDKs verwendet, um auf APIs zuzugreifen, kann sie ihnen darüber hinaus bestimmte begrenzte Standort- und Nutzungsdaten zusammen mit einer kurzlebigen ID senden. Sie löschen diese kurzlebige ID innerhalb von 24 Stunden und verknüpfen sie oder die unverarbeiteten mobilen Standortdaten nicht mit irgendwelchen persönlich identifizierenden Informationen, einschließlich Namen, permanenten IDs, E-Mail-Adressen, IP-Adressen oder Telefonnummern. Mapbox sammelt auch nach dem Zufallsprinzip generierte IDs für den begrenzten Zweck der Analyse der Nutzung ihrer APIs, einschließlich der Anzahl der aktiven Benutzer. Die zufällig generierten IDs und den Inhalt von Anfragen an ihre APIs werden nach 36 Monaten löschen.</p>
-
-<p>Die über ihre APIs und SDKs gesammelten Daten werden (1) für interne Diagnose- und Analysezwecke, (2) zur Verbesserung ihrer Mapping-Produkte und -Dienste, (3) zur Bereitstellung ihrer Dienste für Endbenutzer ihrer Kunden und (4) zur Erstellung aggregierter und anonymisierter Nutzungsstatistiken verwendet.</p>
-
-<p>Weitere Informationen finden Sie in der 
-	<a href="https://www.mapbox.com/legal/privacy/">Datenschutzerklärung von Mapbox</a>.</p>
 
 <h3>IX. Wenn Sie Anmerkungen oder Fragen haben</h3>
 

--- a/themes/codefor-theme/layouts/partials/analytics.html
+++ b/themes/codefor-theme/layouts/partials/analytics.html
@@ -1,0 +1,13 @@
+<script type="text/javascript">
+  var _paq = window._paq = window._paq || [];
+  _paq.push(['disableCookies']);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//traffic.okfn.de/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '5']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>

--- a/themes/codefor-theme/layouts/partials/footer.html
+++ b/themes/codefor-theme/layouts/partials/footer.html
@@ -28,4 +28,5 @@
 
   </div>
 </footer>
+{{ partial "analytics.html" . }}
 {{ end }}

--- a/themes/codefor-theme/layouts/partials/footer.html
+++ b/themes/codefor-theme/layouts/partials/footer.html
@@ -1,8 +1,5 @@
-{{ if ne .Site.Params.hideFooter true }}
 <footer id="footer" class="footer {{ if  not .Params.footerHideTopMargin }}mt-6{{ end }}">
   <div class="container-fluid text-center text-sm-left">
-    
-    
     <div class="row">
       <div class="col-md-12 d-flex align-items-center bg-primary px-7 py-5 px-sm-10 px-md-5 p-lg-7 p-xl-10">
         <div class="w-100">
@@ -29,4 +26,3 @@
   </div>
 </footer>
 {{ partial "analytics.html" . }}
-{{ end }}

--- a/themes/codefor-theme/layouts/partials/head.html
+++ b/themes/codefor-theme/layouts/partials/head.html
@@ -30,4 +30,5 @@
   {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
   {{ end -}}
 
+  {{ partial "analytics.html" . }}
 </head>

--- a/themes/codefor-theme/layouts/partials/head.html
+++ b/themes/codefor-theme/layouts/partials/head.html
@@ -30,5 +30,4 @@
   {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
   {{ end -}}
 
-  {{ partial "analytics.html" . }}
 </head>


### PR DESCRIPTION
This commit adds back Matomo for analytics.
The instance is hosted by the Open Knowledge Foundation so
we can consider it privacy-consious.

I also made sure to add the line
```
_paq.push(['disableCookies']);
```
which disables setting a cookie on the users browser. This does
not allow us to track users across sesssions, what we mostly care
about though is the overall impressions - i.e. which pages do
people look at and when. We do not care about individual behaviour
at all.