### PR TITLE
Twitter timeline hidden, unless loaded

### DIFF
--- a/themes/codefor-theme/assets/scss/main.scss
+++ b/themes/codefor-theme/assets/scss/main.scss
@@ -259,3 +259,7 @@ blockquote {
     margin-bottom: 15px;
 }
 
+// hide element, e.g. twitter timeline
+.hidden {
+  display:none;
+}

--- a/themes/codefor-theme/assets/scss/main.scss
+++ b/themes/codefor-theme/assets/scss/main.scss
@@ -259,7 +259,3 @@ blockquote {
     margin-bottom: 15px;
 }
 
-// hide element, e.g. twitter timeline
-.hidden {
-  display:none;
-}

--- a/themes/codefor-theme/layouts/blog/list.html
+++ b/themes/codefor-theme/layouts/blog/list.html
@@ -13,8 +13,9 @@
                 {{ partial "blog-preview.html" . }}
             {{ end }}
 
+            <!-- For Twitter we add the hidden class which will be removed in script below -->
             {{if eq $paginator.PageNumber 1}}
-            <div class="col-24 col-md-12 mb-5 mb-md-7 project-preview-container twitter-container" >
+            <div class="col-24 col-md-12 mb-5 mb-md-7 project-preview-container twitter-container hidden" >
                 <a class="twitter-timeline" data-height="100%" href="https://twitter.com/codeforde?ref_src=twsrc%5Etfw">Tweets by codeforde</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
             </div>
             {{end}}
@@ -37,6 +38,8 @@ $( document ).ready(function() {
     var totalPages = $('#blog-entries-container').data('total-pages');
     var currentpage = 1;
     var loading = false;
+    setTimeout(checkTwitter,3000); // check for twitter
+
 
     $('#loadMore').click(function(){
         currentpage++;
@@ -54,6 +57,20 @@ $( document ).ready(function() {
 
     });
 });
+
+function checkTwitter() {
+		try {
+            // twitter-widget-0 will be inserted by twitter widget.js upon loading
+            // show container only if this happens ...
+			var f = document.getElementById("twitter-widget-0");
+			f.parentNode.classList.remove("hidden");
+			} catch {
+				console.log("No twitter widget");
+			}
+			//setTimeout(checkTwitter,1000)
+	}
+
+
 </script>
 
 {{ end }}

--- a/themes/codefor-theme/layouts/blog/list.html
+++ b/themes/codefor-theme/layouts/blog/list.html
@@ -15,7 +15,7 @@
 
             <!-- For Twitter we add the hidden class which will be removed in script below -->
             {{if eq $paginator.PageNumber 1}}
-            <div class="col-24 col-md-12 mb-5 mb-md-7 project-preview-container twitter-container hidden" >
+            <div class="col-24 col-md-12 mb-5 mb-md-7 project-preview-container twitter-container d-none" >
                 <a class="twitter-timeline" data-height="100%" href="https://twitter.com/codeforde?ref_src=twsrc%5Etfw">Tweets by codeforde</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
             </div>
             {{end}}

--- a/themes/codefor-theme/layouts/blog/list.html
+++ b/themes/codefor-theme/layouts/blog/list.html
@@ -38,7 +38,7 @@ $( document ).ready(function() {
     var totalPages = $('#blog-entries-container').data('total-pages');
     var currentpage = 1;
     var loading = false;
-    setTimeout(checkTwitter,3000); // check for twitter
+    setTimeout(checkTwitter, 3000); // execute twitter widget check after a delay
 
 
     $('#loadMore').click(function(){

--- a/themes/codefor-theme/layouts/blog/list.html
+++ b/themes/codefor-theme/layouts/blog/list.html
@@ -59,18 +59,11 @@ $( document ).ready(function() {
 });
 
 function checkTwitter() {
-		try {
-            // twitter-widget-0 will be inserted by twitter widget.js upon loading
-            // show container only if this happens ...
-			var f = document.getElementById("twitter-widget-0");
-			f.parentNode.classList.remove("hidden");
-			} catch {
-				console.log("No twitter widget");
-			}
-			//setTimeout(checkTwitter,1000)
-	}
-
-
+    var widgetNode = document.querySelector("#twitter-widget-0");
+    if (widgetNode) {
+        widgetNode.parentNode.classList.remove("d-none");
+    }
+}
 </script>
 
 {{ end }}


### PR DESCRIPTION
Twitter timeline on Blog hidden by default, to suppress anoying (almost) empty tile on Firefox strict privacy.  Tile shown after successful loading. Introduces a small delay, could be shortend, maybe.
