### PR TITLE
Automatically create snapshots with percy.io

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -1,0 +1,20 @@
+name: Visual tests
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.79.1'
+      - name: Build
+        run: hugo
+      - name: Percy Test
+        uses: percy/snapshot-action@v0.1.0
+        with:
+          build-directory: "public/"
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -10,6 +10,7 @@ jobs:
         uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: '0.79.1'
+          extended: true
       - name: Build
         run: hugo
       - name: Percy Test

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Build
         run: hugo
       - name: Percy Test
-        uses: percy/snapshot-action@v0.1.0
+        uses: percy/snapshot-action@v0.1.2
         with:
           build-directory: "public/"
         env:

--- a/.percy.yml
+++ b/.percy.yml
@@ -1,4 +1,4 @@
 version: 1
 static-snapshots:
   path: public/
-  snapshot-files: './index.html,./berlin/index.html,./mitmachen/index.html,./projekte/index.html,./blog/code-for-berlin-talks/index.html'
+  snapshot-files: './index.html,./berlin/index.html,./mitmachen/index.html,./projekte/index.html,./blog/code-for-berlin-talks/index.html,./projekte/pricemap-eu/index.html'

--- a/.percy.yml
+++ b/.percy.yml
@@ -1,0 +1,4 @@
+version: 1
+static-snapshots:
+  path: public/
+  snapshot-files: './index.html,./berlin/index.html,./mitmachen/index.html,./projekte/index.html,./blog/code-for-berlin-talks/index.html'


### PR DESCRIPTION
I was about to take a look at #216 or to start work on disabling the according in the lab view. As this is going to be a visual change that needs to be tested in multiple browsers and resolutions and one can never be sure what parts of a website changes to CSS are going to impact, I thought that it might be worth giving percy a try. 

Using GitHub-actions, this will automatically take screenshots of a predefined set of pages (currently this is  `/`,`/berlin/`,`/mitmachen/`,`/projekte/`,`/blog/code-for-berlin-talks/`,`/projekte/pricemap-eu/` but I am happy to add more) and let us approve/review them if there are any visual changes.

I don't have any prior experience with the tool myself but I think it would be cool to test it. If the other maintainers also sign up for a free account on percy.io, I can add you to the project so that you can approve changes. I have also set it up so that even people that are not logged in should be able to see the diffs that get generated in PRs. 