### PR TITLE
Simplify rendering of headline-brackets shortcodes

### DIFF
--- a/themes/codefor-theme/assets/scss/breakpoints/_1200up.scss
+++ b/themes/codefor-theme/assets/scss/breakpoints/_1200up.scss
@@ -47,17 +47,6 @@ h1,h2{
     font-size: $fontSizeBase-xl - 3;
   }
 
-.headline-brackets{
-    span:first-child{
-      font-size: $fontSizeH1-xl + 28px;
-      margin-top: 4px;
-    }
-    span:last-child{
-      font-size: $fontSizeH1-xl + 28px;
-      margin-top: 4px;
-    }
-}
-
 //---------------------------------------------------
 // Icons
 

--- a/themes/codefor-theme/assets/scss/breakpoints/_992up.scss
+++ b/themes/codefor-theme/assets/scss/breakpoints/_992up.scss
@@ -43,13 +43,3 @@ h1,h2{
   font-size: $fontSizeBase-lg - 3;
 }
 
-.headline-brackets{
-    span:first-child{
-      font-size: $fontSizeH1-lg + 28px;
-      margin-top: 4px;
-    }
-    span:last-child{
-      font-size: $fontSizeH1-lg + 28px;
-      margin-top: 4px;
-    }
-}

--- a/themes/codefor-theme/assets/scss/main.scss
+++ b/themes/codefor-theme/assets/scss/main.scss
@@ -259,3 +259,37 @@ blockquote {
     margin-bottom: 15px;
 }
 
+.headline-brackets {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1.5rem;
+  margin-bottom: 3rem;
+
+  &.blue {
+    &:before, &:after {
+      color: $codefor-blue;
+    }
+  }
+
+  &.red {
+    &:before, &:after {
+      color: $codefor-red;
+    }
+  }
+
+  &:before, &:after {
+    font-size: 1.7em;
+  }
+
+  &:before {
+    content: '{';
+    margin-right: 1.5rem;
+  }
+
+  &:after {
+    content: '}';
+    margin-left: 1.5rem;
+  }
+
+}

--- a/themes/codefor-theme/assets/scss/main.scss
+++ b/themes/codefor-theme/assets/scss/main.scss
@@ -265,6 +265,7 @@ blockquote {
   justify-content: center;
   margin-top: 1.5rem;
   margin-bottom: 3rem;
+  text-align: center;
 
   &.blue {
     &:before, &:after {

--- a/themes/codefor-theme/layouts/blog/single.html
+++ b/themes/codefor-theme/layouts/blog/single.html
@@ -5,8 +5,7 @@
     <img src="/img/section-icon/icon-power.svg" alt="">
 </div>
 
-{{ $color := "blue"}}
-{{ partial "headline-brackets-h1.html" (dict "context" . "txt" .Title "color" $color ) }}
+<h1 class="headline-brackets blue">{{.Title}}</h1>
 
 
 

--- a/themes/codefor-theme/layouts/labs/single.html
+++ b/themes/codefor-theme/layouts/labs/single.html
@@ -94,7 +94,7 @@
 {{ $lab_projects := (where (where .Site.RegularPages "Layout" "==" "project") ".Params.lab" "intersect" $filename)}}
 {{ if len $lab_projects | ne 0 }}
 
-{{ partial "headline-brackets-h2.html" (dict "context" . "txt" "Projekte" "color" "red" ) }}
+<h2 class="headline-brackets">Projekte</h2>
 <div class="row justify-content-center mb-5 mb-lg-7">
     <div class="col-22 col-md-18">
         <div class="row">

--- a/themes/codefor-theme/layouts/labs/single.html
+++ b/themes/codefor-theme/layouts/labs/single.html
@@ -94,7 +94,7 @@
 {{ $lab_projects := (where (where .Site.RegularPages "Layout" "==" "project") ".Params.lab" "intersect" $filename)}}
 {{ if len $lab_projects | ne 0 }}
 
-<h2 class="headline-brackets">Projekte</h2>
+<h2 class="headline-brackets red">Projekte</h2>
 <div class="row justify-content-center mb-5 mb-lg-7">
     <div class="col-22 col-md-18">
         <div class="row">

--- a/themes/codefor-theme/layouts/partials/headline-brackets-h1.html
+++ b/themes/codefor-theme/layouts/partials/headline-brackets-h1.html
@@ -1,5 +1,0 @@
-<h1 class="headline-brackets d-flex justify-content-center align-items-center px-2 mt-4 mb-5 {{ .color }} {{ .class }}  ">
-    <span class="pr-2 pr-sm-3 pr-md-4">{</span>
-    <span class="text-center">{{ .txt }}</span>
-    <span class="pl-2 pl-sm-3 pl-md-4">}</span>
-</h1>

--- a/themes/codefor-theme/layouts/partials/headline-brackets-h2.html
+++ b/themes/codefor-theme/layouts/partials/headline-brackets-h2.html
@@ -1,5 +1,0 @@
-<h2 class="headline-brackets d-flex justify-content-center align-items-center px-2 mt-4 mb-5 {{ .color }} {{ .class }}  ">
-    <span class="pr-2 pr-sm-3 pr-md-4">{</span>
-    <span class="text-center">{{ .txt }}</span>
-    <span class="pl-2 pl-sm-3 pl-md-4">}</span>
-</h2>

--- a/themes/codefor-theme/layouts/projekte/single.html
+++ b/themes/codefor-theme/layouts/projekte/single.html
@@ -8,9 +8,7 @@
   {{ end }}
 </div>
 
-{{ $txt := .Title }}
-{{ $color := "red" }}
-{{ partial "headline-brackets-h1.html" (dict "context" . "txt" $txt "color" $color ) }}
+<h1 class="headline-brackets red">{{.Title}}</h1>
 
 <div class="row justify-content-center blog-content mb-4 mb-md-5">
     <div class="col-22 col-lg-16 col-xl-14">

--- a/themes/codefor-theme/layouts/shortcodes/headline-brackets-h1.html
+++ b/themes/codefor-theme/layouts/shortcodes/headline-brackets-h1.html
@@ -1,4 +1,3 @@
-{{ $txt := .Inner | markdownify }}
-{{ $color := .Get "color" }}
-{{ $class := .Get "class" }}
-{{ partial "headline-brackets-h1.html" (dict "context" . "txt" $txt "color" $color "class" $class) }}
+<h1 class='headline-brackets {{ .Get "color" }} {{ .Get "class" }}'>
+  {{ .Inner | markdownify }}
+</h1>

--- a/themes/codefor-theme/layouts/shortcodes/headline-brackets-h2.html
+++ b/themes/codefor-theme/layouts/shortcodes/headline-brackets-h2.html
@@ -1,5 +1,3 @@
-
-{{ $txt := .Inner | markdownify }}
-{{ $color := .Get "color" }}
-{{ $class := .Get "class" }}
-{{ partial "headline-brackets-h2.html" (dict "context" . "txt" $txt "color" $color "class" $class) }}
+<h2 class='headline-brackets {{ .Get "color" }} {{ .Get "class" }}'>
+  {{ .Inner | markdownify }}
+</h2>

--- a/themes/codefor-theme/layouts/shortcodes/home/teaser-climate.html
+++ b/themes/codefor-theme/layouts/shortcodes/home/teaser-climate.html
@@ -2,11 +2,9 @@
     <div class="col-23 col-sm-24 col-md-22 col-lg-18">
         <div class="row flex-column flex-sm-row justify-content-around align-items-center">
             <div class="col-9 col-sm-4 col-lg-4 col-xl-3 d-flex justify-content-center py-4 py-sm-5"><img class="img-fluid" src="/img/icon-code-climate-left.svg" alt=""></div>
-            <div class="headline-brackets d-flex justify-content-center align-items-center col-auto text-hero text-white ">
-                <span class="pr-2 pr-sm-3 pr-md-4">{</span>
-                <span class="text-center" >Code for Climate</span>
-                <span class="pl-2 pl-sm-3 pl-md-4">}</span>
-            </div>
+            <h2 class="headline-brackets text-white">
+                Code for Climate
+            </h2>
             <div class="col-9 col-sm-4 col-lg-4 col-xl-3 d-flex justify-content-center py-4 py-sm-5"><img class="img-fluid" src="/img/icon-code-climate-right.svg" alt=""></div>
         </div>
     </div>


### PR DESCRIPTION
This change utilises pseudo-elements for the brackets
themselves. This has multiple benefits
1) It reduces the count of DOM-nodes
2) It allows selecting the heading text again