### PR TITLE
Render "hero" element in the Stuttgart lab

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -1,4 +1,4 @@
 version: 1
 static-snapshots:
   path: public/
-  snapshot-files: './index.html,./berlin/index.html,./mitmachen/index.html,./projekte/index.html,./blog/code-for-berlin-talks/index.html,./projekte/pricemap-eu/index.html'
+  snapshot-files: './index.html,./berlin/index.html,./stuttgart/index.html,./mitmachen/index.html,./projekte/index.html,./blog/code-for-berlin-talks/index.html,./projekte/pricemap-eu/index.html'

--- a/content/labs/stuttgart.md
+++ b/content/labs/stuttgart.md
@@ -52,8 +52,8 @@ leads:
   url: mailto:rajko@codefor.de
   username_twitter: ricki_z
   username_github: ricki-z
-
-  hero: Home of sensor.community
+  
+hero: Home of sensor.community
 
 ---
 


### PR DESCRIPTION
Stuttgart is the only lab which utilises the "hero" element from the archetype.
This commit therefore
- makes sure that the yaml is formatted so that this is actually displayed
- registers the Stuttgart page with percy so that we get visual diffs