### PR TITLE
Simplify how lab page is rendered

### DIFF
--- a/themes/codefor-theme/assets/scss/main.scss
+++ b/themes/codefor-theme/assets/scss/main.scss
@@ -292,5 +292,9 @@ blockquote {
     content: '}';
     margin-left: 1.5rem;
   }
+}
 
+.lab-content {
+  max-width: 60ch;
+  margin: 0 auto
 }

--- a/themes/codefor-theme/layouts/labs/single.html
+++ b/themes/codefor-theme/layouts/labs/single.html
@@ -3,7 +3,9 @@
 
 <div class="lab-content">
     <h1 class="d-flex align-items-center flex-wrap justify-content-center">
-        <img src="/labs/hexagon/CodeFor-{{ .File.BaseFileName }}.svg" alt="Logo {{ .Title }}">
+        {{- if (fileExists (printf "static/labs/hexagon/CodeFor-%s.svg" .File.BaseFileName)) -}}
+            <img src="/labs/hexagon/CodeFor-{{ .File.BaseFileName }}.svg" alt="Logo {{ .Title }}">
+        {{- end }}
         <div class="flex-grow-1"> {{.Title}} </div>
     </h1>
 

--- a/themes/codefor-theme/layouts/labs/single.html
+++ b/themes/codefor-theme/layouts/labs/single.html
@@ -2,12 +2,12 @@
 
 
 <div class="lab-content">
-    <h1 class="d-flex align-items-center flex-wrap justify-content-center">
+    <div class="d-flex align-items-center flex-wrap justify-content-center">
         {{- if (fileExists (printf "static/labs/hexagon/CodeFor-%s.svg" .File.BaseFileName)) -}}
             <img src="/labs/hexagon/CodeFor-{{ .File.BaseFileName }}.svg" alt="Logo {{ .Title }}">
         {{- end }}
-        <div class="flex-grow-1"> {{.Title}} </div>
-    </h1>
+      <h1 class="headline-brackets blue flex-grow-1 m-0">{{.Title}} </h1>
+</div>
 
     {{ if .Params.Hero }}
     {{ partial "hero-block-center.html" (dict "context" . "txt" .Params.Hero ) }}

--- a/themes/codefor-theme/layouts/labs/single.html
+++ b/themes/codefor-theme/layouts/labs/single.html
@@ -1,85 +1,44 @@
 {{ define "main" }}
 
-<div class="lab-icon d-flex justify-content-center">
-    <img src="/labs/hexagon/CodeFor-{{ .File.BaseFileName }}.svg" alt="Logo {{ .Title }}">
-</div>
 
-<h1 class="text-center mb-4 mb-lg-6">{{.Title}}</h1>
+<div class="lab-content">
+    <h1 class="d-flex align-items-center flex-wrap justify-content-center">
+        <img src="/labs/hexagon/CodeFor-{{ .File.BaseFileName }}.svg" alt="Logo {{ .Title }}">
+        <div class="flex-grow-1"> {{.Title}} </div>
+    </h1>
 
-{{ partial "hero-block-center.html" (dict "context" . "txt" .Params.Hero ) }}
+    {{ if .Params.Hero }}
+    {{ partial "hero-block-center.html" (dict "context" . "txt" .Params.Hero ) }}
+    {{ end }}
 
-{{ $txt := .Content }}
-<div class="freetext-container">
-    {{ partial "paragraph-center.html" (dict "context" . "txt" $txt ) }}
-</div>
+    <section>
+        {{ .Content }}
+    </section>
 
 
-<div class="row justify-content-center my-8">
-	<div class="col-22 col-md-18 col-lg-16 col-xl-15">
-		<div class="accordion" id="accordionCode">
+    <div class="d-flex flex-wrap">
+      <section class="flex-grow-1">
+          <h3>Kontakt</h3>
+          <ul class="list-unstyled mb-5">
+              {{ range .Params.Leads }}
+              <li class="d-flex  p-2">
+                  <a class="d-block text-dark" href="{{ .url }}">{{ .name }}</a>
+              </li>
+              {{ end }}
+          </ul>
+        </section>
 
-            <div class="card open">
-                <div class="card-header px-0" id="heading-participate-1">
-                    <div class="d-flex justify-content-between">
-                        <button class="btn btn-link text-dark collapsed pl-0" type="button" data-toggle="collapse" data-target="#collapse-participate-1" aria-expanded="true" aria-controls="collapse-participate-1">
-                            <h3>Kontakt</h3>
-                        </button>
-                        <button class="collapsed btn btn-close" type="button" data-toggle="collapse" data-target="#collapse-participate-1" aria-expanded="true" aria-controls="collapse-participate-1">
-                            <img class="img-fluid" src="/img/close-icon.svg">
-                        </button>
-                    </div>
-
-                </div>
-
-                <div id="collapse-participate-1" class="collapse show" aria-labelledby="heading-participate-1" data-parent="#accordionCode">
-                    <div class="card-body py-0">
-                        <div class="row justify-content-center">
-                            <div class="col-20 py-4">
-                                <ul class="list-unstyled mb-5">
-                                    {{ range .Params.Leads }}
-                                    <li class="d-flex justify-content-center p-2">
-                                        <a class="d-block text-dark" href="{{ .url }}">{{ .name }}</a>
-                                    </li>
-                                    {{ end }}
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="card">
-                <div class="card-header px-0" id="heading-participate-2">
-                    <div class="d-flex justify-content-between">
-                        <button class="btn btn-link text-dark collapsed pl-0" type="button" data-toggle="collapse" data-target="#collapse-participate-2" aria-expanded="true" aria-controls="collapse-participate-2">
-                            <h3>Links</h3>
-                        </button>
-                        <button class="collapsed btn btn-close" type="button" data-toggle="collapse" data-target="#collapse-participate-2" aria-expanded="true" aria-controls="collapse-participate-2">
-                            <img class="img-fluid" src="/img/close-icon.svg">
-                        </button>
-                    </div>
-
-                </div>
-
-                <div id="collapse-participate-2" class="collapse" aria-labelledby="heading-participate-2" data-parent="#accordionCode">
-                    <div class="card-body py-0">
-                        <div class="row justify-content-center">
-                            <div class="col-20 py-4">
-                                <ul class="list-unstyled mb-5">
-                                    {{ range .Params.Links }}
-                                    <li>
-                                        <a class="d-block text-center text-dark" href="{{ .url }}">{{ .name }}</a>
-                                    </li>
-                                    {{ end }}
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-		</div>
-	</div>
+        <section class="flex-grow-1">
+        <h3>Links</h3>
+            <ul class="list-unstyled mb-5">
+            {{ range .Params.Links }}
+            <li>
+                <a class="d-block  text-dark" href="{{ .url }}">{{ .name }}</a>
+            </li>
+            {{ end }}
+        </ul>
+        </section>
+    </div>
 </div>
 
 {{/*


### PR DESCRIPTION
- Show all content without accordion
- Remove al to of bootstrap classes for a more
  simple layout