### PR TITLE
Add json output for Labs and Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,15 @@ git push
 │   └── LICENSE --------------> Lizenz der Website
 ```
 
-## Maschinen lesbare Daten der Labs und aller Projekte (simple API)
+## Maschinenlesbare Daten der Labs und aller Projekte (simple API)
 
-Für Labs und Projekte wir automatisch ein JSON erzeugt welches sich unter `/projekte/index.json` bzw. unter `/labs/index.json` befindet.  
+Eine maschinenlesbare Repräsentation der Labs und Projekte in JSON-Format lassen sich unter `/projekte/index.json` bzw. unter `/labs/index.json` abrufen.
+
+**Wichtig**:
+
+Das Schema der Daten kann sich jederzeit ändern.
   
-Die Liste der Labs sieht so aus `/labs/index.json`
+### Beispiel `/labs/index.json`
 
 ``` JSON
 {
@@ -138,7 +142,7 @@ Die Liste der Labs sieht so aus `/labs/index.json`
 
 ```
 
-Die Liste der Projekte sieht so aus `/projekte/index.json`
+### Beispiel `/projekte/index.json`
 
 ``` JSON
 {
@@ -156,8 +160,6 @@ Die Liste der Projekte sieht so aus `/projekte/index.json`
 }
 
 ```
-
-
 
 ## Lizenz
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,50 @@ git push
 │   └── LICENSE --------------> Lizenz der Website
 ```
 
+## Maschinen lesbare Daten der Labs und aller Projekte (simple API)
+
+Für Labs und Projekte wir automatisch ein JSON erzeugt welches sich unter `/projekte/index.json` bzw. unter `/labs/index.json` befindet.  
+  
+Die Liste der Labs sieht so aus `/labs/index.json`
+
+``` JSON
+{
+  "labs":[
+    {
+      "description":"Hier ist das komplette Markdown der Seite ohne 'front matter' (Header)",
+      "metadata":{" Hier stehen alle Informationen die im 'front matter' (Header) stehen"}
+    },
+    {
+      "description":"",
+      "metadata":{""}
+    }
+
+  ]
+}
+
+```
+
+Die Liste der Projekte sieht so aus `/projekte/index.json`
+
+``` JSON
+{
+  "projects":[
+    {
+      "description":"Hier ist das komplette Markdown der Seite ohne 'front matter' (Header)",
+      "metadata":{" Hier stehen alle Informationen die im 'front matter' (Header) stehen"}
+    },
+    {
+      "description":"",
+      "metadata":{""}
+    }
+
+  ]
+}
+
+```
+
+
+
 ## Lizenz
 
 Code: [MIT](./LICENSE). Inhalt: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/deed.de).

--- a/content/labs/_index.md
+++ b/content/labs/_index.md
@@ -1,5 +1,8 @@
 ---
 title: OK Labs
+outputs:
+- html
+- json
 ---
 
 In unseren OK Labs verbinden wir Menschen mit ähnlichen Interessen aus ganz unterschiedlichen Bereichen. Gemeinsam arbeiten wir an Anwendungen und Visualisierungen, die Offene Daten befreien und so Informationen für alle Menschen zugänglich machen. Durch die Einbindung in das bundesweite Code for Germany Netzwerk streuen wir unsere Ergebnisse in unterschiedlichste Teile der Gesellschaft und verhelfen dem digitalen Ehrenamt zu noch mehr Sichtbarkeit.

--- a/content/projekte/_index.md
+++ b/content/projekte/_index.md
@@ -4,6 +4,9 @@ menu:
   main:
     weight: 40
     name: Projekte
+outputs:
+- html
+- json
 ---
 
 

--- a/themes/codefor-theme/layouts/labs/list.json
+++ b/themes/codefor-theme/layouts/labs/list.json
@@ -1,5 +1,6 @@
 {
   "labs": [
-  {{ range .Pages }}{{ dict "metadata" .Params "description" .RawContent | jsonify }},{{ end }}
+    {{ $len := (len .Pages) }}
+    {{ range $index, $element := .Pages }}{{ dict "metadata" .Params "description" .RawContent | jsonify }}{{ if ne (add $index 1) $len }},{{ end }}{{ end }}
   ]
 }

--- a/themes/codefor-theme/layouts/labs/list.json
+++ b/themes/codefor-theme/layouts/labs/list.json
@@ -1,0 +1,5 @@
+{
+  "labs": [
+  {{ range .Pages }}{{ dict "metadata" .Params "description" .RawContent | jsonify }},{{ end }}
+  ]
+}

--- a/themes/codefor-theme/layouts/projekte/list.json
+++ b/themes/codefor-theme/layouts/projekte/list.json
@@ -1,0 +1,5 @@
+{
+  "projects": [
+  {{ range .Pages }}{{ dict "metadata" .Params "description" .RawContent | jsonify }},{{ end }}
+  ]
+}

--- a/themes/codefor-theme/layouts/projekte/list.json
+++ b/themes/codefor-theme/layouts/projekte/list.json
@@ -1,5 +1,6 @@
 {
   "projects": [
-  {{ range .Pages }}{{ dict "metadata" .Params "description" .RawContent | jsonify }},{{ end }}
+    {{ $len := (len .Pages) }}
+    {{ range $index, $element := .Pages }}{{ dict "metadata" .Params "description" .RawContent | jsonify }}{{ if ne (add $index 1) $len }},{{ end }}{{ end }}
   ]
 }


### PR DESCRIPTION
There is already a PR on this topic with a different approach which was unfortunately not completed https://github.com/okfde/codefor.de/pull/206

The `front matter` configuration on `content/labs/_index.md` and `content/projekte/_index.md` ensures that only for these two pages a json is generated.

The `jsonify` function takes an object and converts it to an RFC 8259 compliant JSON object.

 