### PR TITLE
fix #243 - format of H3 on project preview

### DIFF
--- a/themes/codefor-theme/layouts/partials/project-preview.html
+++ b/themes/codefor-theme/layouts/partials/project-preview.html
@@ -17,7 +17,7 @@
               {{ else }}
               {{ .LinkTitle }}
               {{ end }}
-                
+
             </li>
       {{ end }}
     </ul>
@@ -26,8 +26,17 @@
     <div class="card-body p-4">
       <a class="text-dark no-underline" href="{{.Permalink}}"><h3>{{.Title}}</h3></a>
       <div class="text-dark" >
-        {{.Params.Excerpt}}
-        {{.Content | truncate 200 }}
+
+        {{ if (isset .Params "Excerpt") }}
+         {{ if (gt (len .Params.Excerpt) 0)}}
+            {{ .Params.Excerpt | truncate 200 }}
+          {{ else }}
+            {{ .Summary | truncate 200 }}
+          {{ end }}
+        {{ else }}
+          {{ .Summary | truncate 200 }}
+        {{ end }}
+
       </div>
     </div>
     <div class="card-footer border-top-0 bg-white d-flex justify-content-between">


### PR DESCRIPTION
The preview of projects where the first heading of the article is included has been fixed. #243 

For the preview there is an automatically generated summary in hugo.

If the Project has a "Excerpt" set and it's not empty, the "Excerpt" will be displayed!