### PR TITLE
Fixed path if type is blog

### DIFF
--- a/themes/codefor-theme/layouts/partials/head.html
+++ b/themes/codefor-theme/layouts/partials/head.html
@@ -82,7 +82,11 @@
   {{ $imgalt := "CodeFor Germany Logo"}}
 
   {{ if (isset .Params "og_image") }}
-    {{ $permalink = print .Type "s/" .Params.og_image | absURL }}
+    {{ if ne .Type "blog"}}
+      {{ $permalink = print .Type "s/" .Params.og_image | absURL }}
+    {{ else }}
+      {{ $permalink = print .Type "/" .Params.og_image | absURL }}
+    {{ end }}
     {{ if (isset .Params "og_description") }}
       {{ $imgalt = .Params.og_description }}
     {{ end }}


### PR DESCRIPTION
Wenn es ein blogpost ist, liegt die Datei nicht im Ordner blog[s] bei labs und projects muss aber weiterhin ein s angehängt werden

@okfde/codeforde-devs