### PR TITLE
Show attribution in blog header images

### DIFF
--- a/content/blog/2021-08-01-out-in-the-open-juli.md
+++ b/content/blog/2021-08-01-out-in-the-open-juli.md
@@ -6,6 +6,7 @@ excerpt: Monatlich erscheinender Überblick über Entwicklungen in der Open Data
 topic: community
 images:
 - imgname: out-in-the-open-2021-07/header.jpg
+  attribution: Foto von [Finn Hackshaw](https://unsplash.com/@finnhackshaw) auf [Unsplash](https://unsplash.com/s/photos/open)
 
 og_image: out-in-the-open-2021-07/header.jpg
 

--- a/themes/codefor-theme/assets/scss/breakpoints/_base.scss
+++ b/themes/codefor-theme/assets/scss/breakpoints/_base.scss
@@ -287,7 +287,7 @@ nav.navbar{
 .langSwitch  {
   margin-right: 3rem;
   text-decoration: none;
-  
+
   &:hover {
     text-decoration: none;
 }
@@ -464,5 +464,15 @@ footer{
   }
   .details-content {
     background-color: #fff;
+  }
+}
+
+// custom figure element
+figure figcaption {
+  text-align: right;
+  .attribution, .attribution a {
+    font-size: 0.9rem;
+    color: gray;
+    align-self: flex-end;
   }
 }

--- a/themes/codefor-theme/layouts/blog/single.html
+++ b/themes/codefor-theme/layouts/blog/single.html
@@ -1,23 +1,25 @@
 
 {{ define "main" }}
 
-<div class="headline-icon d-flex justify-content-center   ">
+<div class="headline-icon d-flex justify-content-center">
     <img src="/img/section-icon/icon-power.svg" alt="">
 </div>
 
 <h1 class="headline-brackets blue">{{.Title}}</h1>
-
-
-
 
 <div class="row justify-content-center blog-content mb-4 mb-md-5">
     <div class="col-23 col-sm-20 col-lg-14 col-xl-11">
 
         {{ if .Params.images }}
             {{ range first 1 .Params.images}}
-            <div class="text-center">
+            <figure>
                 <img class="img-fluid" src="/blog/{{ .imgname }}" alt="{{ .alt }}">
-            </div>
+                <figcaption>
+                    <div class="attribution">
+                        {{ .attribution | markdownify}}
+                    </div>
+                </figcaption>
+            </figure>
             {{end}}
         {{ end }}
 


### PR DESCRIPTION
Fixes #283

Dies ist die Version, bei der die Attribution unter den Bildern angezeigt wird.