### PR TITLE
Fix image attribution display on large screens

### DIFF
--- a/themes/codefor-theme/assets/scss/breakpoints/_base.scss
+++ b/themes/codefor-theme/assets/scss/breakpoints/_base.scss
@@ -468,11 +468,17 @@ footer{
 }
 
 // custom figure element
-figure figcaption {
-  text-align: right;
-  .attribution, .attribution a {
-    font-size: 0.9rem;
-    color: gray;
-    align-self: flex-end;
+figure {
+  display: flex;
+  flex-direction: column;
+
+  figcaption {
+    text-align: right;
+
+    .attribution, .attribution a {
+      font-size: 0.9rem;
+      color: gray;
+      align-self: flex-end;
+    }
   }
 }

--- a/themes/codefor-theme/layouts/blog/single.html
+++ b/themes/codefor-theme/layouts/blog/single.html
@@ -13,7 +13,7 @@
         {{ if .Params.images }}
             {{ range first 1 .Params.images}}
             <figure>
-                <img class="img-fluid" src="/blog/{{ .imgname }}" alt="{{ .alt }}">
+                <img src="/blog/{{ .imgname }}" alt="{{ .alt }}">
                 <figcaption>
                     <div class="attribution">
                         {{ .attribution | markdownify}}


### PR DESCRIPTION
This was noticed because the image that was uploaded for the last blogpost
has rather small intrinsic dimensions (width of 640px) and would not grow
to the full width of the page. The attribution would still be right aligned
though which looked odd.

By converting the `figure` to use `display: flex` we can ensure that the image
is displayed in full width and properly aligns with the attribution again.

Fixes #291


|before|after|
|----|---|
|![before](https://user-images.githubusercontent.com/1096357/132100021-5fbb5578-6cf8-4893-b2c7-b26d781361bb.png)|![after](https://user-images.githubusercontent.com/1096357/132100042-9951bafd-d42b-4575-96ba-e6bb9fdfbdb0.png)|

