### PR TITLE
Hide leaflet tiles when taking percy screenshots

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -2,3 +2,9 @@ version: 1
 static-snapshots:
   path: public/
   snapshot-files: './index.html,./berlin/index.html,./stuttgart/index.html,./mitmachen/index.html,./projekte/index.html,./blog/code-for-berlin-talks/index.html,./projekte/pricemap-eu/index.html'
+  # Do not render leaflet tiles in percy so that changes
+  # in OSM do not lead to changes in our snapshots
+  percy-css: |
+    .leaflet-tile-container {
+      display: none !important;
+    }


### PR DESCRIPTION
With almost every change that we push, percy shows us changes.
This is because part of our website is a map which renders
OpenStreetMap tiles. Whenever those tiles change, percy notices
that as a change (even though this is of course independent from
our actual website) and marks the screenshot as a change.

With this change, we hide all leaflet tiles so that they no longer
get displayed and hence cannot cause changes in our screenshots
anymore.