### PR TITLE
Update links for OKLab Potsdam

### DIFF
--- a/content/labs/potsdam.md
+++ b/content/labs/potsdam.md
@@ -14,11 +14,8 @@ members: []
 
 links:
 
-- name: Homepage
-  url: http://www.oklab-potsdam.de
-
-- name: Meetup
-  url: http://www.meetup.com/OK-Lab-Potsdam
+- name: GetTogether
+  url: https://gettogether.community/ok-lab-potsdam/
 
 - name: Twitter
   url: https://twitter.com/oklabpdm


### PR DESCRIPTION
- domain for the website has expired, only shows Sedo Parking
- Meetup group does not seem to exist anymore, replace that with GetTogether