### PR TITLE
Replace deprecated percy-snapshot-action

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -14,8 +14,6 @@ jobs:
       - name: Build
         run: hugo
       - name: Percy Test
-        uses: percy/snapshot-action@v0.1.2
-        with:
-          build-directory: "public/"
+        run: npx @percy/cli snapshot public/
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.percy.yml
+++ b/.percy.yml
@@ -1,10 +1,12 @@
-version: 1
-static-snapshots:
-  path: public/
-  snapshot-files: './index.html,./berlin/index.html,./stuttgart/index.html,./mitmachen/index.html,./projekte/index.html,./blog/code-for-berlin-talks/index.html,./projekte/pricemap-eu/index.html'
-  # Do not render leaflet tiles in percy so that changes
-  # in OSM do not lead to changes in our snapshots
-  percy-css: |
-    .leaflet-tile-container {
-      display: none !important;
-    }
+version: 2
+static:
+  include: 
+    - ./index.html
+    - ./berlin/index.html
+    - ./stuttgart/index.html
+    - ./mitmachen/index.html
+    - ./projekte/index.html
+    - ./blog/code-for-berlin-talks/index.html
+    - ./projekte/pricemap-eu/index.html
+discovery:
+  disable-cache: true

--- a/themes/codefor-theme/assets/scss/map.scss
+++ b/themes/codefor-theme/assets/scss/map.scss
@@ -52,3 +52,9 @@
     z-index: 20000;
     width: 100%;
   }
+
+@media only percy {
+  .leaflet-tile-container {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
As per the [readme](https://github.com/percy/snapshot-action), this
action was deprecated in favor of just running `npx percy` as in this
commit. A failing build on our side triggered this requirement. See
[build logs](https://github.com/okfde/codefor.de/actions/runs/1677073844).