### PR TITLE
Remove legacy Meetup link for Heidelberg

### DIFF
--- a/content/labs/heidelberg.md
+++ b/content/labs/heidelberg.md
@@ -17,8 +17,6 @@ members:
   username_github: mandyr
 
 links:
-- name: Meetup
-  url: http://www.meetup.com/OK-Lab-Heidelberg/
 - name: Pad
   url: https://pad.ccc-mannheim.de/p/OKL-HD_Portal
 - name: Twitter


### PR DESCRIPTION
The Meetup group `OK-Lab-Heidelberg` no longer exists. Though the other two links refer to *old* content, I would suggest to remove *broken* links.