### PR TITLE
Fix filters on project overview page https://codefor.de/projekte/

### DIFF
--- a/themes/codefor-theme/layouts/partials/project-preview.html
+++ b/themes/codefor-theme/layouts/partials/project-preview.html
@@ -1,21 +1,21 @@
-<div class="col-24 col-md-12 col-lg-12 col-xl-8 mb-3  {{ range (.GetTerms "tags") }}{{ .LinkTitle }} {{end}}">
+<div class="col-24 col-md-12 col-lg-12 col-xl-8 mb-3  {{ range (.Param "tags") }}{{ . }} {{end}}">
   <div class="card border-dark h-100" href="{{.Permalink}}">
     <div class="card-header border-bottom-0 bg-white ">
       <ul class="d-flex list-unstyled justify-content-end m-0 p-0">
-        {{ range (.GetTerms "tags") }}
+        {{ range (.Param "tags") }}
 
             <li class="pl-3">
 
-              {{ if eq .LinkTitle "Umwelt" }}
-              <img class="img-fluid taxonomie-icon" src="/img/taxonomie-icon/umwelt.svg" alt="{{.LinkTitle}}">
-              {{ else if eq .LinkTitle "Politik" }}
-              <img class="img-fluid taxonomie-icon" src="/img/taxonomie-icon/politik.svg" alt="{{.LinkTitle}}">
-              {{ else if eq .LinkTitle "Gesellschaft" }}
-              <img class="img-fluid taxonomie-icon" src="/img/taxonomie-icon/gesellschaft.svg" alt="{{.LinkTitle}}">
-              {{ else if eq .LinkTitle "Mobilität" }}
-              <img class="img-fluid taxonomie-icon" src="/img/taxonomie-icon/mobilitaet.svg" alt="{{.LinkTitle}}">
+              {{ if eq . "Umwelt" }}
+              <img class="img-fluid taxonomie-icon" src="/img/taxonomie-icon/umwelt.svg" alt="{{ . }}">
+              {{ else if eq . "Politik" }}
+              <img class="img-fluid taxonomie-icon" src="/img/taxonomie-icon/politik.svg" alt="{{ . }}">
+              {{ else if eq . "Gesellschaft" }}
+              <img class="img-fluid taxonomie-icon" src="/img/taxonomie-icon/gesellschaft.svg" alt="{{ . }}">
+              {{ else if eq . "Mobilität" }}
+              <img class="img-fluid taxonomie-icon" src="/img/taxonomie-icon/mobilitaet.svg" alt="{{ . }}">
               {{ else }}
-              {{ .LinkTitle }}
+              {{ . }}
               {{ end }}
 
             </li>


### PR DESCRIPTION
This pull request adds the project's tags on the [overview page](https://codefor.de/projekte/) again as little icons for each. Also, this fixes the currently broken filter buttons.

Screenshot:

![Screenshot from 2022-05-31 23-40-09](https://user-images.githubusercontent.com/881988/171289247-4e29c5eb-6680-4b20-ad95-867c510099a5.png)

With warm greetings to @digital-codes :)
