### PR TITLE
Dynamically calulate number of labs in the Overview block on the home page

### DIFF
--- a/data/home/aufEinenBlick.json
+++ b/data/home/aufEinenBlick.json
@@ -6,8 +6,7 @@
     },
     {
         "title": "Labs",
-        "img": "CFG_labs.svg",
-        "count": 31
+        "img": "CFG_labs.svg"
     },
     {
         "title": "Ehrenamtliche",

--- a/themes/codefor-theme/layouts/shortcodes/home/block-auf-einen-blick.html
+++ b/themes/codefor-theme/layouts/shortcodes/home/block-auf-einen-blick.html
@@ -5,7 +5,12 @@
             <img class="img-fluid w-100" src="/icons/{{ $element.img }}" alt="">
         </div>
         <div class="text-center text-hero">
-            {{ $element.count }}
+            {{ if eq $element.title "Labs" }}
+                {{- $labs := where (where $.Site.RegularPages ".Params.city" "!=" nil) ".Params.hide" "!=" true -}}
+                {{ len $labs }}
+            {{ else }}
+                {{ $element.count }}
+            {{ end }}
         </div>
         <div class="text-center">
             {{ $element.title }}


### PR DESCRIPTION
This basically inlines what's already available in the `num-labs.html` shortcode.

Resolves #340.