### PR TITLE
Add missing redirect to legacy URL https://codefor.de/code-of-conduct/

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1406,3 +1406,7 @@ to = "/archiv/opendataday18/"
 [[ redirects ]]
 from = "/feed.xml"
 to = "/index.xml"
+
+[[ redirects ]]
+from = "/code-of-conduct/"
+to = "/grundsaetze/"


### PR DESCRIPTION
See [discussion](https://openknowledgegermany.slack.com/archives/C0470CVSV/p1655799762410229) in Slack channel `#codeforde-website`