### PR TITLE
Aliase anlegen für Labs mit Kfz-Kennzeichen mit Mindestlänge 2

### DIFF
--- a/content/labs/bielefeld.md
+++ b/content/labs/bielefeld.md
@@ -8,6 +8,7 @@ markerposition: right
 
 aliases:
 - /bielefeld
+- /bi
 
 members:
 

--- a/content/labs/bonn.md
+++ b/content/labs/bonn.md
@@ -7,6 +7,7 @@ markerposition: right
 
 aliases:
 - /bonn
+- /bn
 
 members:
 

--- a/content/labs/cottbus.md
+++ b/content/labs/cottbus.md
@@ -8,6 +8,7 @@ showsignup: true # true | false
 
 aliases:
 - /cottbus
+- /cb
 
 members:
 - name: "Benji"

--- a/content/labs/dresden.md
+++ b/content/labs/dresden.md
@@ -7,6 +7,7 @@ markerposition: right
 
 aliases:
 - /dresden
+- /dd
 
 members:
 

--- a/content/labs/erlangen.md
+++ b/content/labs/erlangen.md
@@ -9,6 +9,7 @@ hide: true
 
 aliases:
 - /erlangen
+- /er
 
 ---
 

--- a/content/labs/freiburg.md
+++ b/content/labs/freiburg.md
@@ -7,6 +7,7 @@ hide: true
 
 aliases:
 - /freiburg
+- /fr
 
 members:
 

--- a/content/labs/giessen.md
+++ b/content/labs/giessen.md
@@ -7,6 +7,7 @@ markerposition: right
 
 aliases:
 - /giessen
+- /gi
 
 showsignup: false
 

--- a/content/labs/hamburg.md
+++ b/content/labs/hamburg.md
@@ -7,6 +7,7 @@ markerposition: left
 
 aliases:
 - /hamburg
+- /hh
 
 members:
 

--- a/content/labs/heidelberg.md
+++ b/content/labs/heidelberg.md
@@ -8,6 +8,7 @@ markerposition: left
 
 aliases:
 - /heidelberg
+- /hd
 
 members:
 - name: Jasper Schmidt

--- a/content/labs/heilbronn.md
+++ b/content/labs/heilbronn.md
@@ -7,6 +7,7 @@ markerposition: right
 
 aliases:
 - /heilbronn
+- /hn
 
 members:
 - name: Adrian Stabiszewski

--- a/content/labs/kaiserslautern.md
+++ b/content/labs/kaiserslautern.md
@@ -8,6 +8,7 @@ markerposition: left
 
 aliases:
 - /kaiserslautern
+- /kl
 
 members:
 - name: Falco Nogatz

--- a/content/labs/karlsruhe.md
+++ b/content/labs/karlsruhe.md
@@ -8,6 +8,7 @@ markerposition: left
 
 aliases:
 - /karlsruhe
+- /ka
 
 #special: true #this lab gets spcecial marker (digital refugee lab)
 

--- a/content/labs/magdeburg.md
+++ b/content/labs/magdeburg.md
@@ -6,6 +6,7 @@ long: 11.62941
 
 aliases:
 - /magdeburg
+- /md
 
 members:
 

--- a/content/labs/muenster.md
+++ b/content/labs/muenster.md
@@ -6,6 +6,7 @@ long: 7.62
 
 aliases:
 - /muenster
+- /ms
 
 members:
 

--- a/content/labs/osnabrueck.md
+++ b/content/labs/osnabrueck.md
@@ -9,6 +9,7 @@ showsignup: false
 
 aliases:
 - /osnabrueck
+- /os
 
 members:
 - name: Peer Wagner

--- a/content/labs/paderborn.md
+++ b/content/labs/paderborn.md
@@ -6,6 +6,7 @@ hide: true
 
 aliases:
 - /paderborn
+- /pb
 
 members:
 

--- a/content/labs/ulm.md
+++ b/content/labs/ulm.md
@@ -8,6 +8,7 @@ markerposition: left
 
 aliases:
 - /ulm
+- /ul
 
 members:
 


### PR DESCRIPTION
Viele Labs benennen sich (z.B. auf Twitter, GitHub und Meetup) als `CodeforX`, wobei `X` das Kfz-Kennzeichen der Region ist. Wie im OKF-Slack [angesprochen](https://openknowledgegermany.slack.com/archives/C0470CVSV/p1656066757270859), wollte ich daher gerne einen entsprechenden Alias haben, damit auch die entsprechenden URLs `codefor.de/X` funktionieren, also bspw. `https://codefor.de/kl` für [Kaiserslautern](https://codefor.de/kaiserslautern/). In diesem PR werden die Aliase für alle Labs ergänzt, deren Kfz-Kennzeichen mindestens zwei Zeichen lang ist (sorry, Stuttgart, `codefor.de/s` fand ich dann schon nicht mehr allzu intuitiv :joy:).

Hugo erzeugt daraus neue Rewrites dieser Form:

```diff
 rewrite ^/kaiserslautern$ /kaiserslautern/ permanent;
+rewrite ^/kl$ /kaiserslautern/ permanent;
 rewrite ^/muenster$ /muenster/ permanent;
+rewrite ^/ms$ /muenster/ permanent;
```

Außerdem werden Weiterleitungen als Ordner `/kl/` angelegt, damit auch `codefor.de/kl/` umleitet:

```html
<!doctype html><html lang=de-de><head><title>https://codefor.de/kaiserslautern/</title><link rel=canonical href=https://codefor.de/kaiserslautern/><meta name=robots content="noindex"><meta charset=utf-8><meta http-equiv=refresh content="0; url=https://codefor.de/kaiserslautern/"></head></html>
```