### PR TITLE
Add blogposts to labs

### DIFF
--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -5,6 +5,7 @@ author: Oliver OpenData  # wenn nicht vorhanden steht da dann codeforde
 twitter_handle: # wenn nicht vorhanden steht da dann @codeforde
 excerpt: Ein bis zwei Sätze die den Blogpost beschreiben. Wird für die Blogliste verwendet.
 topic: event # zb event, community, default, interview, project, story, toolbox
+lab: [bielefeld] # Zur Übersicht auf der Lab-Seite
 images:
    - imgname: bild.jpg # Dieses Bild sollte im Verzeichnis static/blog existieren
 

--- a/content/blog/2014-04-14-Gruendung-OK-Lab-Chemnitz.md
+++ b/content/blog/2014-04-14-Gruendung-OK-Lab-Chemnitz.md
@@ -9,6 +9,7 @@ topic: event
 images:
 - imgname: chemnitz/2014-04-14-First-meetup.jpg
   sub: Interessierte
+lab: [chemnitz]
 
 ---
 

--- a/content/blog/2014-04-25-einladung-gruendung-muenchen.md
+++ b/content/blog/2014-04-25-einladung-gruendung-muenchen.md
@@ -8,6 +8,7 @@ topic: event
 images:
 - imgname: muenchen/rathaus-muc.jpg
   sub: Münchner Rathaus (CC-by-sa blue-news.org on flickr)
+lab: [muenchen]
 
 ---
 

--- a/content/blog/2014-05-22-gruendung-muenchen.md
+++ b/content/blog/2014-05-22-gruendung-muenchen.md
@@ -4,6 +4,7 @@ type: blog
 title: Gründungstreffen des OK Lab München
 author: Matt
 topic: event
+lab: [muenchen]
 
 images:
 - imgname: muenchen/cfmgruendung.jpg

--- a/content/blog/2014-05-23-oklab-muenster.md
+++ b/content/blog/2014-05-23-oklab-muenster.md
@@ -5,6 +5,7 @@ title: Das OK Lab Muenster
 author: Fiona
 excerpt: Welche Köpfe stecken eigentlich hinter dem OK Lab Müster?
 topic: community
+lab: [muenster]
 
 ---
 

--- a/content/blog/2014-05-27-oklab-chemnitz.md
+++ b/content/blog/2014-05-27-oklab-chemnitz.md
@@ -4,6 +4,7 @@ type: blog
 title: Das OK Lab Chemitz
 author: Fiona
 topic: community
+lab: [chemnitz]
 
 images:
 - imgname: morris.jpg

--- a/content/blog/2014-06-21-OK-Lab-mit-Herrn-Both.md
+++ b/content/blog/2014-06-21-OK-Lab-mit-Herrn-Both.md
@@ -4,6 +4,7 @@ type: blog
 title: OK-Lab Berlin mit Gästen
 author: Magda
 topic: community
+lab: [berlin]
 
 images:
 - imgname: berlin/ok_lab_mit_both_1.jpg

--- a/content/blog/2014-07-02-muenchen-projekte.md
+++ b/content/blog/2014-07-02-muenchen-projekte.md
@@ -5,6 +5,7 @@ title: "Letztes und nächstes Treffen: Projekte!"
 author: Matt
 excerpt: Ein kleines Update aus dem OK Lab München - was war, was ist, was kommt?
 topic: story
+lab: [muenchen]
 
 tags:
 - Aus den Labs

--- a/content/blog/2014-07-03-Datenquellen.md
+++ b/content/blog/2014-07-03-Datenquellen.md
@@ -4,6 +4,7 @@ type: blog
 title: Datenquellen
 author: Magda
 topic: toolbox
+lab: [berlin]
 
 ---
 

--- a/content/blog/2014-07-03-lab-profiles-berlin.md
+++ b/content/blog/2014-07-03-lab-profiles-berlin.md
@@ -5,6 +5,7 @@ title: Das OK Lab Berlin
 author: Fiona
 excerpt: Das OK Lab Berlin ist das größte der bisher vierzehn Labs. Bei so vielen kreativen Köpfen lohnt es sich, einmal genauer hinzuschauen und in den Projekten zu stöbern.
 topic: project
+lab: [berlin]
 
 tags:
 - Aus den Labs

--- a/content/blog/2014-07-03-lab-profiles-hamburg.md
+++ b/content/blog/2014-07-03-lab-profiles-hamburg.md
@@ -5,6 +5,7 @@ title: Das Hamburger OK Lab
 author: Fiona
 excerpt: Die Jungs und Mädels aus Hamburg sind absolute Experten auf dem Gebiet der Datenvisualisierung und unheimlich gut vernetzt. Wir wollen sie näher vorstellen...
 topic: community
+lab: [hamburg]
 
 tags:
 - Aus den Labs

--- a/content/blog/2014-07-03-lab-profiles-heilbronn.md
+++ b/content/blog/2014-07-03-lab-profiles-heilbronn.md
@@ -5,6 +5,7 @@ title: Das OK Lab Heilbronn
 author: Fiona
 excerpt: Das OK Lab in Heilbronn ist eines dieser kleinen, aber umwerfend feinen Labs. Eine Handvoll Interessierter hat gemeinsam eine informative Anwendung zur Trinkwasserqualität in der Region gebaut.
 topic: community
+lab: [heilbronn]
 
 tags:
 - Aus den Labs

--- a/content/blog/2014-07-03-lab-profiles-ulm.md
+++ b/content/blog/2014-07-03-lab-profiles-ulm.md
@@ -5,6 +5,7 @@ title: Das OK Lab Ulm
 author: Fiona
 excerpt: Seit 2011 arbeitet eine studentische Gruppe in Ulm mit und zu offenen Daten. In Zusammenarbeit mit der Stadt entstehen dabei Anwendungen, die auf die Bedürfnisse der Bürger und Bürgerinnen zugeschnitten sind.
 topic: community
+lab: [ulm]
 
 images:
 - imgname: ulm.jpg

--- a/content/blog/2014-08-08-treffen-muenchen.md
+++ b/content/blog/2014-08-08-treffen-muenchen.md
@@ -4,6 +4,7 @@ type: blog
 title: Nächstes Treffen des OK Lab München
 author: Matt
 topic: story
+lab: [muenchen]
 
 ---
 

--- a/content/blog/2014-09-17-jugend-hackt.md
+++ b/content/blog/2014-09-17-jugend-hackt.md
@@ -5,6 +5,7 @@ title: Jugend hackt
 author: Fiona
 excerpt: Am Wochenende fand „Jugend hackt“ in Berlin statt. Ein Wochenende lang programmierten, hackten und bastelten Jugendliche
 topic: event
+lab: [berlin]
 
 images:
 - imgname: jugendhackt.jpg

--- a/content/blog/2014-10-07-muenchen-codeweek-eu.md
+++ b/content/blog/2014-10-07-muenchen-codeweek-eu.md
@@ -5,6 +5,7 @@ title: München macht mit bei Codeweek EU
 author: Matt
 excerpt: Die Codeweek EU steht vor der Tür - und wir machen mit!
 topic: event
+lab: [muenchen]
 
 ---
 

--- a/content/blog/2014-10-31-muenchen-hackday.md
+++ b/content/blog/2014-10-31-muenchen-hackday.md
@@ -5,6 +5,7 @@ title: Code for Munich Hack Day
 author: Matt
 excerpt: Unser erster Hackathon - mach mit!
 topic: event
+lab: [muenchen]
 
 images:
 - imgname: hackathon-muenchen.png

--- a/content/blog/2014-11-17-transparenztag-hamburg.md
+++ b/content/blog/2014-11-17-transparenztag-hamburg.md
@@ -5,6 +5,7 @@ title: Transparenztag in Hamburg am 23.11.
 author: Fiona
 excerpt: Das OK Lab Hamburg lädt ein zum Transparenztag. Mit EntwicklerInnen und JournalistInnen wird das neue Portal erkundet und ausprobiert.
 topic: event
+lab: [hamburg]
 
 images:
 - imgname: codeforhamburg.png

--- a/content/blog/2014-12-08-Open-Data-in-Freiburg.md
+++ b/content/blog/2014-12-08-Open-Data-in-Freiburg.md
@@ -5,6 +5,7 @@ title: Open Freiburg - Let's Go!
 author: Fiona
 excerpt: In Freiburg geht es vorwärts in Sachen Open Data - am Donnerstag, den 11.12. sind wir zu Gast bei einer Veranstaltung rund um Offene Daten und diskutieren die Gründung eines neuen OK Labs!
 topic: community
+lab: [freiburg]
 
 images:
 - imgname: Open-Data-Freiburg.gif

--- a/content/blog/2014-12-15-Transparenz-in-Hamburg.md
+++ b/content/blog/2014-12-15-Transparenz-in-Hamburg.md
@@ -5,6 +5,7 @@ title: Transparenz in Hamburg
 author: Fiona
 excerpt: In Hamburg haben sich Coder und Journalisten getroffen, um gemeinsam das neu gelaunchte Transparenzportal zu erkunden. Hier gibt's Links zu den Ergebnissen.
 topic: toolbox
+lab: [hamburg]
 
 images:
 - imgname: transparenz-hamburg.png

--- a/content/blog/2015-01-28-muenchen-transparent.md
+++ b/content/blog/2015-01-28-muenchen-transparent.md
@@ -5,6 +5,7 @@ title: "München Transparent"
 author: Fiona
 excerpt: Das OK Lab München hat einen Vorstoß in Richtung mehr Transparenz gewagt und das Portal "München Transparent" gestartet.
 topic: project
+lab: [muenchen]
 
 images:
 - imgname: muenchen-transparent-launch.png

--- a/content/blog/2015-02-11-drew-in-hamburg.md
+++ b/content/blog/2015-02-11-drew-in-hamburg.md
@@ -5,6 +5,7 @@ title: Hamburg Lab is the latest stop on civic tech across borders tour
 author: Drew
 excerpt: A quick recap from Drew's recent presentation at the Code for Hamburg meetup
 topic: story
+lab: [hamburg]
 
 images:
 - imgname: dw-visit-hamburg-1-of-3-2015-2-9.jpg

--- a/content/blog/2015-02-19-die-senatsverwaltung-berlin-zu-gast.md
+++ b/content/blog/2015-02-19-die-senatsverwaltung-berlin-zu-gast.md
@@ -4,6 +4,7 @@ type: blog
 title: Die Senatsverwaltung zu Gast
 author: Tobias
 topic: story
+lab: [berlin]
 
 images:
 - imgname: berlin/fisbroker.jpg

--- a/content/blog/2015-03-02-Digitalisierung-der-Stadt
+++ b/content/blog/2015-03-02-Digitalisierung-der-Stadt
@@ -4,6 +4,7 @@ type: blog
 title: 'Digitalisierung der Stadt' war Thema eines Projekts an der TU Berlin (Institut für Stadt- und Regionalplanung, Fachgebiet Stadt- und Regionalökonomie)
 author: Sonia
 topic: story
+lab: [berlin]
 
 images: Digitalisierung der Stadt: Thema eines Projekts an der TU Berlin
 - imgname: stadtdernerds1.jpg

--- a/content/blog/2015-03-02-digitalisierung-der-Stadt.md
+++ b/content/blog/2015-03-02-digitalisierung-der-Stadt.md
@@ -4,6 +4,7 @@ type: blog
 title: Digitalisierung der Stadt war Thema eines Projekts an der TU Berlin
 author: Sonia
 topic: event
+lab: [berlin]
 
 images:
 - imgname: stadtdernerds1.jpg

--- a/content/blog/2015-03-06-puerto-rico-presentation.md
+++ b/content/blog/2015-03-06-puerto-rico-presentation.md
@@ -5,6 +5,7 @@ title: Stephanie Kruger from Code for Puerto Rico shares lessons & experiences w
 author: Drew
 excerpt: Monday March 9, 2015 - Join Code for Germany for a unique & inspiring presentation by Stephanie Kruger, captain of the Code for Puerto Rico brigade. She will reflect on the past year of organizing, coding, and designing to improve her island.
 topic: event
+lab: [koeln]
 
 images:
 - imgname: stephanie-code-for-puerto-rico.png

--- a/content/blog/2015-03-17-giessen-badeseen.md
+++ b/content/blog/2015-03-17-giessen-badeseen.md
@@ -4,6 +4,7 @@ type: blog
 title: OK Lab Gießen beim hessischen Erfahrungsaustausch für Badegewässer
 author: Marco und Vince
 topic: project
+lab: [giessen]
 
 images:
 - imgname: cfgibadeseen2.jpg

--- a/content/blog/2015-05-13-das-war-der-hack-your-city-kickoff-in-berlin.md
+++ b/content/blog/2015-05-13-das-war-der-hack-your-city-kickoff-in-berlin.md
@@ -5,6 +5,7 @@ title: Das war der Hack Your City Kickoff in Berlin
 author: Fiona
 excerpt: In Berlin haben Entwicklerinnen und Stadtforscher zwei Tage Projekte für die Stadt der Zukunft entworfen
 topic: event
+lab: [berlin]
 
 images:
 - imgname: hackyourcity-berlin.jpg

--- a/content/blog/2015-05-21-pen-and-paper-hackathon-in-koeln.md
+++ b/content/blog/2015-05-21-pen-and-paper-hackathon-in-koeln.md
@@ -5,6 +5,7 @@ title: Pen & Paper Hackathon zu Verkehr, Mobilität und Stadtentwicklung
 author: Marcel
 excerpt: In Köln kommen Designer, Architekt, Stadtplaner, Programmierer und engagierter Bürger zusammen, um die Mobilität in der Stadt neu zu denken.
 topic: event
+lab: [koeln]
 
 images:
 - imgname: cologne/penandpaper.jpg

--- a/content/blog/2015-07-01-heilbronn-kickoff.md
+++ b/content/blog/2015-07-01-heilbronn-kickoff.md
@@ -5,6 +5,7 @@ title: Stadräte zu Gast bei Code for Heilbronn
 author: Felix
 excerpt: In Heilbronn haben wir zu einer Informationsveranstaltung über Open Data eingeladen. Unterstützt wurden wir dabei von Gerd Armbruster, Leiter der IT in der Stadt Mannheim.
 topic: community
+lab: [heilbronn]
 
 images:
 - imgname: heilbronn-kickoff.jpg

--- a/content/blog/2015-08-07-sebastian-askar-der-neue-open-data-beauftragte-fuer-berlin.md
+++ b/content/blog/2015-08-07-sebastian-askar-der-neue-open-data-beauftragte-fuer-berlin.md
@@ -5,6 +5,7 @@ title: Sebastian Askar - der neue Open Data Beauftragte von Berlin
 author: Tobias, Thomas und Knut
 excerpt: Berlin hat einen neuen Open Data Beauftragten - Sebastian Askar. Sein Vorgänger Dr. Both geht in den Ruhestand und Sebastian Askar übernimmt seine Stelle. Dies nahmen wir als Berliner Open Data Lab zum Anlass, ihn einzuladen. Am 20. Juli 2015 war es soweit - Sebastian Askar kam ins OKLab Berlin. Was bei diesem gegenseitigen Kennenlernen besprochen wurde, soll dieser Artikel festhalten.
 topic: event
+lab: [berlin]
 ---
 
 # Sebastian Askar - der neue Open Data Beauftragte von Berlin

--- a/content/blog/2015-08-07-tierheimbot.md
+++ b/content/blog/2015-08-07-tierheimbot.md
@@ -5,6 +5,7 @@ title: Ein <3 für Tiere
 author: Eileen
 excerpt: Ein Twitterbot macht gerade die Runden.
 topic: project
+lab: [chemnitz]
 
 images:
 - imgname: cutepetseverywhere.png

--- a/content/blog/2015-08-31-stadtgeschichte-magdego-magdeburg.md
+++ b/content/blog/2015-08-31-stadtgeschichte-magdego-magdeburg.md
@@ -1,6 +1,7 @@
 ---
 author: Eileen Wagner
 type: blog
+lab: [magdeburg]
 color: green #one of: red, blue, green, cyan
 pattern: 4 #one of: 1, 2, 3, 4
 og-image: /blog/stories/magdego-hero.jpg # used for facebook & twitter card

--- a/content/blog/2015-08-31-stadtgeschichte-muenchen-transparent-muenchen.md
+++ b/content/blog/2015-08-31-stadtgeschichte-muenchen-transparent-muenchen.md
@@ -1,6 +1,7 @@
 ---
 author: Eileen Wagner
 type: blog
+lab: [muenchen]
 color: cyan #one of: red, blue, green, cyan
 pattern: 1 #one of: 1, 2, 3, 4
 og-image: /blog/stories/Muenchen-Transparent.png # used for facebook & twitter card

--- a/content/blog/2015-08-31-stadtgeschichte-parkenDD-dresden.md
+++ b/content/blog/2015-08-31-stadtgeschichte-parkenDD-dresden.md
@@ -1,6 +1,7 @@
 ---
 author: Eileen Wagner
 type: blog
+lab: [dresden]
 color: blue #red, blue, green, cyan
 pattern: 3 #one of: 1, 2, 3, 4
 og-image: /blog/stories/parkendd-hero.jpg # used for facebook & twitter card

--- a/content/blog/2015-08-31-story-magdego-magdeburg.md
+++ b/content/blog/2015-08-31-story-magdego-magdeburg.md
@@ -1,6 +1,7 @@
 ---
 author: Eileen Wagner
 type: blog
+lab: [magdeburg]
 lang: en
 color: green #one of: red, blue, green, cyan
 pattern: 4 #one of: 1, 2, 3, 4

--- a/content/blog/2015-08-31-story-muenchen-transparent-munich.md
+++ b/content/blog/2015-08-31-story-muenchen-transparent-munich.md
@@ -1,6 +1,7 @@
 ---
 author: Eileen Wagner
 type: blog
+lab: [muenchen]
 lang: en
 color: cyan #one of: red, blue, green, cyan
 pattern: 1 #one of: 1, 2, 3, 4

--- a/content/blog/2015-08-31-story-parkenDD-dresden.md
+++ b/content/blog/2015-08-31-story-parkenDD-dresden.md
@@ -1,6 +1,7 @@
 ---
 author: Eileen Wagner
 type: blog
+lab: [dresden]
 lang: en
 color: blue #red, blue, green, cyan
 pattern: 3 #one of: 1, 2, 3, 4

--- a/content/blog/2015-09-22-cyclehack.md
+++ b/content/blog/2015-09-22-cyclehack.md
@@ -5,6 +5,7 @@ title: Fahrräder hacken mit dem OK Lab Wuppertal
 author: Ann-Cathrin & Sam
 excerpt: Am Wochenende vom 19. bis 21. Juni fand der erste Wuppertaler Cyclehack bei uns im Utopiastadt statt.
 topic: event
+lab: [wuppertal]
 images:
 - imgname: cyclehackwuppertal.jpg
 

--- a/content/blog/2015-10-06-tech-for-refugees.md
+++ b/content/blog/2015-10-06-tech-for-refugees.md
@@ -4,6 +4,7 @@ title: Tech for Refugees
 author: Ulrike
 excerpt: Es gibt derzeit zahlreiche Tech-Projekte rund um Geflüchtete. Ulrike aus dem OK Lab Berlin hat angefangen, eine Übersicht zu erstellen, um die Vernetzung der Initiativen zu fördern und vorhandene Projekte besser auffindbar zu machen. Hier erklärt sie, wie sie das macht und wie ihr mithelfen könnt
 topic: project
+lab: [berlin]
 
 images:
 - imgname: refugees-welcome.png

--- a/content/blog/2015-10-14-muenchentransparenttalk.md
+++ b/content/blog/2015-10-14-muenchentransparenttalk.md
@@ -4,6 +4,7 @@ type: blog
 title: Vortrag auf den Open Government Tage der Stadt München von Bernd Oswald
 author: Matt
 topic: interview
+lab: [muenchen]
 
 ---
 

--- a/content/blog/2015-11-04-vanessawormer.md
+++ b/content/blog/2015-11-04-vanessawormer.md
@@ -5,6 +5,7 @@ title: Code for Journalism
 author: Eileen
 excerpt: Interview mit Vanessa Wormer
 topic: interview
+lab: [heilbronn]
 
 images:
 - imgname: wormer.png

--- a/content/blog/2016-06-02-drl-workshop-leipzig.md
+++ b/content/blog/2016-06-02-drl-workshop-leipzig.md
@@ -4,6 +4,7 @@ title: Das war der Kickoff-Workshop in Leipzig
 author: Elisa
 excerpt: Wir haben Eindrücke vom Kickoff-Workshop des Digital Refugee Labs Leipzig gesammelt - es war ein fulminanter Auftakt!
 topic: event
+lab: [leipzig]
 
 images:
 - imgname: drl-leipzig.jpg

--- a/content/blog/2016-07-29-odd-muenchen.md
+++ b/content/blog/2016-07-29-odd-muenchen.md
@@ -3,6 +3,7 @@ type: blog
 title: München Open Data Day Hackathon Projekt Ergebnisse
 author: Matt
 topic: project
+lab: [muenchen]
 tags:
 - Aus den Labs
 excerpt: Es ist inzwischen so lange her, aber dafür kann man ein Bisschen mehr über die damals entstandene Projekte erzählen

--- a/content/blog/2016-07-29-refugeedatathon.md
+++ b/content/blog/2016-07-29-refugeedatathon.md
@@ -3,6 +3,7 @@ type: blog
 title: Refugee Datathon in München, der zweite
 author: Suny
 topic: event
+lab: [muenchen]
 tags:
 - Aus den Labs
 excerpt: Am 18. Juni stieg der zweite Refugee Datathon in München. Diesmal im WERK1 gemeinsam von Welcome Help e.V. und OK Lab München veranstaltet.

--- a/content/blog/2016-11-28-open-data-verwaltung-grundschuleinzugsgebiete.md
+++ b/content/blog/2016-11-28-open-data-verwaltung-grundschuleinzugsgebiete.md
@@ -4,6 +4,7 @@ title: Offene Daten in der Berliner Verwaltung
 author: Niels
 excerpt: Die Zuschneidung von Einzugsgebieten für Grundschulen ist ein komplexes Thema. Im Bezirk Tempelhof-Schöneberg in Berlin wird nun eine Anwendung pilotiert, die mit offenen Daten diese Gebiete algorithmisch optimiert.
 topic: story
+lab: [berlin]
 images:
 - imgname: einzugsgebiete.png
 ---

--- a/content/blog/2016-12-15-wikidata.md
+++ b/content/blog/2016-12-15-wikidata.md
@@ -4,6 +4,7 @@ title: Wikidata-Hackathon
 author: Eileen & Fiona
 excerpt: Im Ulmer Verschwörhaus haben sich die Labs zu einem Wikidata-Hackathon getroffen.
 topic: event
+lab: [ulm]
 images:
 - imgname: wikidata.jpg
 draft: false

--- a/content/blog/2016-12-19-stadtgeschichte-buerger-baut-stadt-berlin.md
+++ b/content/blog/2016-12-19-stadtgeschichte-buerger-baut-stadt-berlin.md
@@ -1,6 +1,7 @@
 ---
 author: Eileen Wagner
 type: blog
+lab: [berlin]
 color: red #red, blue, green, cyan
 pattern: 2 #one of: 1, 2, 3, 4
 og-image: /blog/stories/bbs-hero.jpg # used for facebook & twitter card

--- a/content/blog/2016-12-19-stadtgeschichte-feinstaub-stuttgart.md
+++ b/content/blog/2016-12-19-stadtgeschichte-feinstaub-stuttgart.md
@@ -1,6 +1,7 @@
 ---
 author: Eileen Wagner
 type: blog
+lab: [stuttgart]
 color: red #one of: red, blue, green, cyan
 pattern: 1 #one of: 1, 2, 3, 4
 og-image: /blog/stories/feinstaub.jpg # used for facebook & twitter card

--- a/content/blog/2016-12-19-stadtgeschichte-tal-o-mat-wuppertal.md
+++ b/content/blog/2016-12-19-stadtgeschichte-tal-o-mat-wuppertal.md
@@ -1,6 +1,7 @@
 ---
 author: Eileen Wagner
 type: blog
+lab: [wuppertal]
 color: cyan #one of: red, blue, green, cyan
 pattern: 2 #one of: 1, 2, 3, 4
 og-image: /blog/stories/talomat.jpg # used for facebook & twitter card

--- a/content/blog/2016-12-19-story-air-pollution-stuttgart.md
+++ b/content/blog/2016-12-19-story-air-pollution-stuttgart.md
@@ -1,6 +1,7 @@
 ---
 author: Eileen Wagner
 type: blog
+lab: [stuttgart]
 lang: en
 color: red #one of: red, blue, green, cyan
 pattern: 1 #one of: 1, 2, 3, 4

--- a/content/blog/2016-12-19-story-citizen-builds-city-berlin.md
+++ b/content/blog/2016-12-19-story-citizen-builds-city-berlin.md
@@ -1,6 +1,7 @@
 ---
 author: Eileen Wagner
 type: blog
+lab: [berlin]
 lang: en
 color: red #red, blue, green, cyan
 pattern: 2 #one of: 1, 2, 3, 4

--- a/content/blog/2016-12-19-story-tal-o-mat-wuppertal.md
+++ b/content/blog/2016-12-19-story-tal-o-mat-wuppertal.md
@@ -1,6 +1,7 @@
 ---
 author: Eileen Wagner
 type: blog
+lab: [wuppertal]
 lang: en
 color: cyan #one of: red, blue, green, cyan
 pattern: 2 #one of: 1, 2, 3, 4

--- a/content/blog/2017-02-02-open-data-heilbronn.md
+++ b/content/blog/2017-02-02-open-data-heilbronn.md
@@ -4,6 +4,7 @@ title: Open Data in Heilbronn - es tut sich was!
 author: Felix Ebert, Code for Heilbronn
 excerpt: Ein Antrag der SPD wurde einstimmig angenommen. Am 04.03. lädt Code for Heilbronn zum Open Data Day ein
 topic: story
+lab: [heilbronn]
 images:
 - imgname: rathaus-heilbronn.jpg
 draft: false

--- a/content/blog/2017-02-08-forum-offene-stadt-hamburg.md
+++ b/content/blog/2017-02-08-forum-offene-stadt-hamburg.md
@@ -4,6 +4,7 @@ title: Forum Offene Stadt Hamburg
 author: Fiona
 excerpt: Das OK Lab Hamburg lädt ein, ins "Forum Offene Stadt" am 03. März
 topic: event
+lab: [hamburg]
 images:
 - imgname: offenestadt.png
 draft: false

--- a/content/blog/2017-06-23-wahlsalons-checkin-einladung.md
+++ b/content/blog/2017-06-23-wahlsalons-checkin-einladung.md
@@ -4,6 +4,7 @@ title: Wahlsalons Check-In am 07. Juli in Köln
 author: Michael
 excerpt: Einladung zum zweiten Wahlsalon
 topic: event
+lab: [koeln]
 images:
 - imgname: wahlsalon-koeln.png
 draft: false

--- a/content/blog/2017-07-17-Wahlsalon-Koeln.md
+++ b/content/blog/2017-07-17-Wahlsalon-Koeln.md
@@ -4,6 +4,7 @@ title: Check-In Köln
 author: Michael
 excerpt: Der zweite Wahlsalon fand diesmal in Köln statt. Gemeinsam mit der Stadt konnten neue und bestehende Projekte vorgestellt und weiterentwickelt werden. Lest hier den Bericht vom Event -
 topic: event
+lab: [koeln]
 images:
 - imgname: wahlsalon-koeln-1.jpg
 draft: false

--- a/content/blog/2017-08-23-Wahlsalon-Berlin-Showroom Kopie.md
+++ b/content/blog/2017-08-23-Wahlsalon-Berlin-Showroom Kopie.md
@@ -4,6 +4,7 @@ title: Wahlsalon Showroom am 01. September in Berlin
 author: Fiona
 excerpt: Am 01. September ist es wieder soweit - der dritte Wahlsalon findet statt und kehrt zurück nach Berlin. Eingeladen sind spannende Projekte und das Büro des Bundeswahlleiters
 topic: event
+lab: [berlin]
 
 images:
 - imgname: wahlsalon-3.png

--- a/content/blog/2017-08-23-Wahlsalon-Berlin-Showroom.md
+++ b/content/blog/2017-08-23-Wahlsalon-Berlin-Showroom.md
@@ -4,6 +4,7 @@ title: Showroom Berlin - so war der dritte Wahlsalon
 author: Fiona
 excerpt: Am vergangenen Freitag fand in Berlin der dritte Wahlsalon statt. Im Showroom stellten sich spannende Civic Tech Projekte rund um die Wahl vor.
 topic: event
+lab: [berlin]
 
 images:
 - imgname: wahlsalon-3.png

--- a/content/blog/2017-10-04-hackathon-chemnitz-hackt-im-oktober.md
+++ b/content/blog/2017-10-04-hackathon-chemnitz-hackt-im-oktober.md
@@ -4,6 +4,7 @@ title: "Hackathon: Chemnitz hackt"
 author: Ronny
 excerpt: Ende Oktober findet in Chemnitz der erste Hackathon „Chemitz hackt“statt. Ein Wochenende lang programmieren, hacken und basteln mit Gleichgesinnten und Offenen Daten.
 topic: event
+lab: [chemnitz]
 
 draft: false
 images:

--- a/content/blog/2017-11-08-mrmcd-2017-ulmer-reisebericht.md
+++ b/content/blog/2017-11-08-mrmcd-2017-ulmer-reisebericht.md
@@ -4,6 +4,7 @@ title: MRMCD 2017 - Ulmer Reisebericht
 author: Sabine
 excerpt: Ein Open-Data-Neuling besucht die Landesdatenschau.
 topic: event
+lab: [ulm]
 
 topic: event
 

--- a/content/blog/2017-11-10-chemnitz-hackt-rueckblick.md
+++ b/content/blog/2017-11-10-chemnitz-hackt-rueckblick.md
@@ -4,6 +4,7 @@ title: "Chemnitz hackt 2017: Rückblick und Projektvorstellung"
 author: Ronny
 excerpt: Der erste (uns bekannte) Chemnitzer Hackathon vom 28. und 29. Oktober 2017 ist nun auch schon wieder vorbei. Dem einen oder anderen wird sicherlich interessieren, wie es so war, was für Projekte rausgekommen sind und ob es genug Pizza gab.
 topic: event
+lab: [chemnitz]
 
 draft: false
 images:

--- a/content/blog/2020-12-14-Code-for-berlin-talks.md
+++ b/content/blog/2020-12-14-Code-for-berlin-talks.md
@@ -3,6 +3,7 @@ type: blog
 title: "OK Lab Berlin - Rückblick auf unsere Vortragsreihe 2020"
 author: Knut Hühne - OK Lab Berlin
 topic: community
+lab: [berlin]
 excerpt: "Das Jahr 2020 geht zu Ende und auch für uns im Berliner Open Knowledge Lab ist so einiges anders gelaufen, als wir uns das ursprünglich vorgestellt haben. Eine Sache die wir und vorgenommen haben - nämlich jeden Monat Expert*innen zu uns ins Lab einzuladen, um uns Vorträge zu ihren Themen anzuhören, konnten wir trotzdem verwirklichen. In diesem Fall hat das Social-Distancing sogar dazu geführt, dass wir deutlich internationaler gedacht haben und nicht nur Gäste aus Berlin, sondern aus der ganzen Welt hatten. In diesem Blogpost wollen wir die Vorträge noch einmal Revue passieren lassen." 
 images:
    - imgname: ok-lab-berlin-rueckblick-2020/fran-jacquier-tmuArUNS1TI-unsplash.png

--- a/content/blog/2021-12-15-Feuchtigkeit-Teutoburger-Wald.md
+++ b/content/blog/2021-12-15-Feuchtigkeit-Teutoburger-Wald.md
@@ -5,6 +5,7 @@ author: Meike Wocken
 twitter_handle: "@CountessOfCount"
 excerpt: "In Bielefeld wird die Feuchtigkeit des heimischen Waldbodens mit Sensoren gemessen. Ziel ist es, dafür eine Citizen Science-Community aufzubauen und die Daten für alle als Open Data und aufbereitet in einer Online-Karte zur Verfügung zu stellen."
 topic: community, project
+lab: [bielefeld]
 images:
  - imgname: feuchtigkeit-teutoburger-wald/teuto_wald2.jpg
  - imgname: feuchtigkeit-teutoburger-wald/teuto_team.jpg # Dieses Bild sollte im Verzeichnis static/blog existieren

--- a/content/blog/2022-06-28-kickoff-kaiserslautern.md
+++ b/content/blog/2022-06-28-kickoff-kaiserslautern.md
@@ -4,6 +4,7 @@ title: "Runde Sache: In Kaiserslautern gibt's nun auch ein OK Lab!"
 author: Falco
 excerpt: Im Rahmen des Digitaltags haben sich vergangene Woche an Open Data interessierte Bürger\*innen getroffen und so den Weg für das erste OK Lab in Rheinland-Pfalz geebnet.
 topic: community
+lab: [kaiserslautern]
 
 images:
 - imgname: kaiserslautern/2022-06-20-kickoff/Anpfiff.jpg

--- a/content/blog/2022-07-04-reallabor-bielefeld.md
+++ b/content/blog/2022-07-04-reallabor-bielefeld.md
@@ -11,6 +11,7 @@ images:
  - imgname: reallabor-bielefeld/reallabor_3.jpg
  - imgname: reallabor-bielefeld/reallabor_4.jpg
  - imgname: reallabor-bielefeld/reallabor_5.jpg
+lab: [bielefeld] #needed for Aggregation on Lab-Page
  
 og_image: reallabor-bielefeld/reallabor_1.jpg
 og_description:  Jens Edler zeigt und erklärt die Sensoren im Bielefelder Reallabor. # Der alt Text zum Titelbildame: bild.jpg # Dieses Bild sollte im Verzeichnis static/blog existieren

--- a/themes/codefor-theme/layouts/labs/single.html
+++ b/themes/codefor-theme/layouts/labs/single.html
@@ -67,6 +67,29 @@
 </div>
 {{ end }}
 
+{{/*
+    Lists blogposts of this lab.
+    Requires blog posts to include the filename
+    without extension of this lab to be in the
+    "labs: [...]" property of the frontmatter of the
+    blogpost file.
+*/}}
+{{/* create a slice because we're using "intersect" in the next line */}}
+{{ $filename := slice .File.BaseFileName }}
+{{ $lab_blogposts := (where (where .Site.RegularPages "Section" "==" "blog") ".Params.lab" "intersect" $filename)}}
+{{ if len $lab_blogposts | ne 0 }}
+<h2 class="headline-brackets red">Was bei uns passiert</h2>
+<div class="row justify-content-center">
+    <div class="col-24 col-md-22 col-lg-17">
+        <div class="row">
+            {{ range $lab_blogposts  }}
+                {{ partial "blog-preview.html" . }}
+            {{ end }}
+        </div>
+    </div>
+</div>
+{{ end }}
+
 <hr/>
 {{ partial "map-overview.html" . }}
 


### PR DESCRIPTION
This PR adds a `Was bei uns passiert` section to the lab pages, listing all blogposts related to the lab.