### PR TITLE
Add ical feed for Kaiserslautern

### DIFF
--- a/content/labs/kaiserslautern.md
+++ b/content/labs/kaiserslautern.md
@@ -30,6 +30,10 @@ links:
 - name: OKF Slack
   url: https://openknowledgegermany.slack.com/messages/kaiserslautern
 
+feeds:
+- type: ical
+  url: https://gettogether.community/team/17065/events.ics
+
 leads:
 - name: E-Mail-Verteiler
   url: mailto:kaiserslautern@codefor.de


### PR DESCRIPTION
Following yesterday's Slack discussion: https://openknowledgegermany.slack.com/archives/C02T0J55PRP/p1664218134667269