### PR TITLE
Resolve hugo warning about zero object

### DIFF
--- a/content/mitmachen.md
+++ b/content/mitmachen.md
@@ -1,5 +1,6 @@
 ---
 title: Mitmachen
+needsLeafletCSS: true
 ---
 {{< headline-icon icon="icon-bracket.svg" >}}
 

--- a/themes/codefor-theme/layouts/partials/css.html
+++ b/themes/codefor-theme/layouts/partials/css.html
@@ -3,7 +3,7 @@
 {{- $cssTarget    := "css/style.css" }}
 {{- $cssOpts      := cond ($inServerMode) (dict "targetPath" $cssTarget "enableSourceMap" true) (dict "targetPath" $cssTarget "outputStyle" "compressed") }}
 
-{{- if (or (eq .Page.File.BaseFileName "mitmachen") (ne .Page.Params.city nil)) -}}
+{{- if (or .Page.Params.needsLeafletCSS (ne .Page.Params.city nil) ) -}}
 <link rel="stylesheet" href="{{ "leaflet/leaflet.css" | absURL }}" />
 {{- end -}}
 


### PR DESCRIPTION
This resolves the warning
```
.File.BaseFileName on zero object. Wrap it in if or with: {{ with .File }}{{ .BaseFileName }}{{ end }}
```
By replacing the check for the .Page.File.BaseFileName with an explicit new prop in the frontmatter which can be added when a page needs to load CSS.

It still is a bit implicit with the `city` param but I think this is better than before and it resolves the warning.