### PR TITLE
Update to latest percy version

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Build
         run: hugo
       - name: Percy Test
-        run: npx @percy/cli@1.8.1 snapshot public/
+        run: npx @percy/cli@1.24.2 snapshot public/
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}


### PR DESCRIPTION
I don't think there are any changes that are important to us but the Percy website kept showing a warning that we were using an outdated version of the CLI.