### PR TITLE
Add closing `paragraph-center` to presse page

### DIFF
--- a/content/presse.md
+++ b/content/presse.md
@@ -198,3 +198,4 @@ n/a 2014 - Wired Magazin\
 
 15.07.2014 - Kick-Off Pressemitteilung\
 [Code for Germany – Die Open Knowledge Foundation startet Programm für digitales Engagement in Kommunen](https://us5.campaign-archive.com/?u=929f1e07936386d34833e20d1&id=c6b9c30dd9&e=[UNIQID])
+{{</ paragraph-center  >}}


### PR DESCRIPTION
This is to fix the following warning:
```
ERROR 2023/06/12 10:31:32 "/Users/knut/projects/codefor.de/content/presse.md:13:1": failed to extract shortcode: shortcode "paragraph-center" must be closed or self-closed
```
The closing tag was accidentally removed in https://github.com/okfde/codefor.de/pull/426