### PR TITLE
Fix header icons on blog and spenden pages

### DIFF
--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -2,7 +2,7 @@
 title: Blog
 ---
 
-{{< headline-icon icon="icon-exclamation.svg" >}}
+{{< headline-icon icon="icon-exclamation.svg" color="red" >}}
 
 {{< headline-brackets-h1 color="blue"  >}}
 Blog

--- a/themes/codefor-theme/layouts/blog/single.html
+++ b/themes/codefor-theme/layouts/blog/single.html
@@ -1,9 +1,7 @@
 
 {{ define "main" }}
 
-<div class="headline-icon d-flex justify-content-center">
-    <img src="/img/section-icon/icon-exclamation.svg" alt="">
-</div>
+{{ partial "headline-icon" (dict "context" . "icon" "icon-exclamation.svg" "color" "red" ) }}
 
 <h1 class="headline-brackets blue">{{.Title}}</h1>
 

--- a/themes/codefor-theme/layouts/partials/headline-icon.html
+++ b/themes/codefor-theme/layouts/partials/headline-icon.html
@@ -1,0 +1,5 @@
+<div class="headline-icon d-flex justify-content-center {{ .color }} ">
+    {{ printf "themes/codefor-theme/static/img/section-icon/%s"  .icon | readFile | safeHTML }}
+</div>
+
+

--- a/themes/codefor-theme/layouts/shortcodes/headline-icon.html
+++ b/themes/codefor-theme/layouts/shortcodes/headline-icon.html
@@ -1,4 +1,3 @@
-<div class="headline-icon d-flex justify-content-center {{ .Get "class" }} {{ .Get "color" }} ">
-    {{ $icon := .Get "icon" }}
-    {{ printf "themes/codefor-theme/static/img/section-icon/%s"  $icon | readFile | safeHTML }}
-</div>
+{{ $icon := .Get "icon" }}
+{{ $color := .Get "color" }}
+{{ partial "headline-icon" (dict "context" . "icon" $icon "color" $color ) }}

--- a/themes/codefor-theme/static/img/section-icon/icon-exclamation.svg
+++ b/themes/codefor-theme/static/img/section-icon/icon-exclamation.svg
@@ -4,7 +4,7 @@
     <g transform="matrix(1,0,0,1,-1106.13,-253.544)">
         <g id="Gruppe_844">
             <path id="Pfad_513" d="M1168.4,329.3C1170.3,329.3 1171.9,330.9 1171.9,332.8C1171.9,334.7 1170.3,336.3 1168.4,336.3C1166.5,336.3 1164.9,334.7 1164.9,332.8C1164.9,330.8 1166.5,329.3 1168.4,329.3Z" style="fill:none;fill-rule:nonzero;stroke:currentColor;stroke-width:3px;"/>
-            <path id="Pfad_514" d="M1129.1,344.9L1110.6,348.4L1122.2,320.8L1122,319.8C1113.4,294.5 1126.9,267.1 1152.2,258.5C1177.3,250 1204.6,263.3 1213.4,288.3C1222.1,313.5 1207.8,339.7 1182.6,348.4C1170.5,352.6 1156.7,350.4 1147.7,345" style="fill:none;fill-rule:nonzero;currentColor;stroke-width:3px;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;"/>
+            <path id="Pfad_514" d="M1129.1,344.9L1110.6,348.4L1122.2,320.8L1122,319.8C1113.4,294.5 1126.9,267.1 1152.2,258.5C1177.3,250 1204.6,263.3 1213.4,288.3C1222.1,313.5 1207.8,339.7 1182.6,348.4C1170.5,352.6 1156.7,350.4 1147.7,345" style="fill:none;fill-rule:nonzero;stroke:currentColor;stroke-width:3px;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;"/>
             <path id="Pfad_515" d="M1167.95,323.855C1168.3,312.877 1168.04,271.686 1168.04,271.686" style="fill:none;fill-rule:nonzero;stroke:currentColor;stroke-width:3px;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;"/>
         </g>
     </g>

--- a/themes/codefor-theme/static/img/section-icon/icon-touch.svg
+++ b/themes/codefor-theme/static/img/section-icon/icon-touch.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 127 68" style="enable-background:new 0 0 127 68;" xml:space="preserve">
 <style type="text/css">


### PR DESCRIPTION
I messed up in #466 and broke some icons.

This PR 
- Convert the `headline-icon` shortcode into a partial and then uses that in the shortcode.  This allow us to also use the `headline-icon` component from the templates. We need this for the individual blog posts
- Fixes the icon for exalamation
- Adds a missing color to the blog icon 