### PR TITLE
Simplify lab map

### DIFF
--- a/themes/codefor-theme/assets/scss/breakpoints/_576up.scss
+++ b/themes/codefor-theme/assets/scss/breakpoints/_576up.scss
@@ -11,14 +11,3 @@ nav.navbar{
       width: 270px;
     }
 }
-
-#lab-map-wrapper{
-  margin-top: 0;
-  .lab-map-dropdown{
-    position: absolute;
-    left: 50px;
-    top: 50px;
-    z-index: 20000;
-    width: 340px;
-  }
-}

--- a/themes/codefor-theme/assets/scss/breakpoints/_768up.scss
+++ b/themes/codefor-theme/assets/scss/breakpoints/_768up.scss
@@ -4,16 +4,6 @@ nav.navbar{
     }
 }
 
-#lab-map-wrapper{
-    padding-bottom: 66%;
-}
-
-.lab-map-dropdown{
-    left: 50px;
-    top: 50px;
-    transform: translate(0)
-}
-
 .langSwitch {
     margin-top: -4rem;
-  }
+}

--- a/themes/codefor-theme/assets/scss/map.scss
+++ b/themes/codefor-theme/assets/scss/map.scss
@@ -1,18 +1,9 @@
-#lab-map-wrapper{
+#lab-map{
     width: 100%;
-    padding-bottom: 150%;
-    position: relative;
-    margin-top: 150px;
+    aspect-ratio: 3/4;
     @media(orientation: landscape){
-      padding-bottom: 100%;
+      aspect-ratio: 16/9;
     }
-  }
-  #lab-map{
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
   }
 
   .leaflet-marker-icon-wrapper {
@@ -42,15 +33,6 @@
       color: $codefor-red;
       text-decoration: none;
     }
-  }
-
-
-  .lab-map-dropdown{
-    position: absolute;
-    left: 0;
-    top: -120px;
-    z-index: 20000;
-    width: 100%;
   }
 
 @media only percy {

--- a/themes/codefor-theme/layouts/partials/lab-map.html
+++ b/themes/codefor-theme/layouts/partials/lab-map.html
@@ -1,7 +1,5 @@
 {{- $labs := where (where .Site.RegularPages ".Params.city" "!=" nil) ".Params.hide" "!=" true }}
-<div id="lab-map-wrapper">
-    <div id="lab-map" ></div>
-</div>
+<div id="lab-map" ></div>
 
 <script src="{{ "leaflet/leaflet.js" | absURL }}"></script>
 <script src="{{ "js/lib/leaflet.iconlabel.js" | absURL }}"></script>


### PR DESCRIPTION
I think a lot of the complexity was around handling 
the orientation of the map (using the old padding trick).
This can be more easily achieved using the 
[well supported](https://caniuse.com/?search=aspect-ratio) 
`aspect-ratio` property nowadays.
