### PR TITLE
Render of page failed

### DIFF
--- a/themes/codefor-theme/layouts/partials/project-preview.html
+++ b/themes/codefor-theme/layouts/partials/project-preview.html
@@ -26,7 +26,7 @@
     </div>
 
     <div class="card-body p-4">
-        {{- if (and (isset .Params "imgname") (fileExists (printf "static/projects/%s" .Params.imgname ))) -}}
+        {{- if (and (not (eq .Params.imgname nil)) (fileExists (printf "static/projects/%s" .Params.imgname ))) -}}
         <img class="project-image" src="/projects/{{ .Params.imgname }}"  alt="Screenshot {{ .Title }}">
         {{- else -}}
         <img class="project-image project-image__placeholder" src="/img/logo.svg"  alt="">

--- a/themes/codefor-theme/layouts/partials/project-preview.html
+++ b/themes/codefor-theme/layouts/partials/project-preview.html
@@ -26,7 +26,7 @@
     </div>
 
     <div class="card-body p-4">
-        {{- if (fileExists (printf "static/projects/%s" .Params.imgname )) -}}
+        {{- if (and (isset .Params "imgname") (fileExists (printf "static/projects/%s" .Params.imgname ))) -}}
         <img class="project-image" src="/projects/{{ .Params.imgname }}"  alt="Screenshot {{ .Title }}">
         {{- else -}}
         <img class="project-image project-image__placeholder" src="/img/logo.svg"  alt="">

--- a/themes/codefor-theme/layouts/projekte/single.html
+++ b/themes/codefor-theme/layouts/projekte/single.html
@@ -23,7 +23,7 @@
           {{ if .Params.status }}
           <p>Status des Projektes {{ .Title }}: {{ .Params.status }}</p>
           {{ end }}
-          {{ if (and (isset .Params "imgname") (fileExists (printf "static/projects/%s" .Params.imgname))) }}
+          {{ if (and (not (eq .Params.imgname nil)) (fileExists (printf "static/projects/%s" .Params.imgname))) }}
           <div class="d-flex align-items-center">
               <img class="img-fluid mx-auto" src="/projects/{{ .Params.imgname }}" alt="Screenshot {{ .Title }}">
           </div>

--- a/themes/codefor-theme/layouts/projekte/single.html
+++ b/themes/codefor-theme/layouts/projekte/single.html
@@ -23,9 +23,9 @@
           {{ if .Params.status }}
           <p>Status des Projektes {{ .Title }}: {{ .Params.status }}</p>
           {{ end }}
-          {{ if (and (isset .Params "imgname") (fileExists (printf "static/projects/%s" .Params.Imgname))) }}
+          {{ if (and (isset .Params "imgname") (fileExists (printf "static/projects/%s" .Params.imgname))) }}
           <div class="d-flex align-items-center">
-              <img class="img-fluid mx-auto" src="/projects/{{ .Params.Imgname }}" alt="Screenshot {{ .Title }}">
+              <img class="img-fluid mx-auto" src="/projects/{{ .Params.imgname }}" alt="Screenshot {{ .Title }}">
           </div>
           {{ end }}
         </div>


### PR DESCRIPTION
This PR solves two issues I had when running the website locally:

```
ERROR render of "page" failed: "C:\Projects\CodeForMD\codefor.de\themes\codefor-theme\layouts\labs\single.html:70:19": execute of template failed: template: labs/single.html:70:19: executing "main" at <partial "project-preview.html" .>: error calling partial: execute of template failed: template: partials/project-preview.html:29:47: executing "partials/project-preview.html" at <fileExists (printf "static/projects/%!s(MISSING)" .Params.imgname)>: error calling fileExists: CreateFile C:\Projects\CodeForMD\codefor.de\static\projects\%!!(MISSING)s(<nil>): The filename, directory name, or volume label syntax is incorrect.
```

and

```
Error: error building site: render: failed to render pages: render of "page" failed: "C:\Projects\CodeForMD\codefor.de\themes\codefor-theme\layouts\labs\single.html:70:19": execute of template failed: template: labs/single.html:70:19: executing "main" at <partial "project-preview.html" .>: error calling partial: execute of template failed: template: partials/project-preview.html:29:47: executing "partials/project-preview.html" at <fileExists (printf "static/projects/%s" .Params.imgname)>: error calling fileExists: CreateFile C:\Projects\CodeForMD\codefor.de\static\projects\%!s(<nil>): The filename, directory name, or volume label syntax is incorrect.
```


Resolves #507 