### PR TITLE
some minor changes for leipzig projects

### DIFF
--- a/content/labs/leipzig.md
+++ b/content/labs/leipzig.md
@@ -15,7 +15,7 @@ aliases:
 members:
 - name: Jörg Reichert
   username_github: joergreichert
-- name: Lisa-Marie Steckel
+- name: Lisa Marie Steckel
   username_github: vrifox
 - name: Erik Oltmann
   username_github: ErikOrtmann

--- a/content/projekte/2018-01-06-le-museen.md
+++ b/content/projekte/2018-01-06-le-museen.md
@@ -6,7 +6,7 @@ title: Museen Mitteldeutschlands
 status: abgeschlossen
 
 links:
-- url: http://damals.in/museums/
+- url: http://damals.codeforleipzig.de/museums/
   name: Website
 - url: https://github.com/CodeforLeipzig/codingdavinciost2018/tree/master/de.oklab.leipzig.cdv.glams
   name: Page on Github

--- a/content/projekte/2018-05-12-le-damals.md
+++ b/content/projekte/2018-05-12-le-damals.md
@@ -6,7 +6,7 @@ title: damals in Leipzig
 status: abgeschlossen
 
 links:
-- url: http://damals.in/leipzig/
+- url: http://damals.codeforleipzig.de/leipzig/
   name: Website
 - url: https://github.com/CodeforLeipzig/codingdavinciost2018
   name: Page on Github
@@ -34,7 +34,7 @@ Außerdem wurden CSV / XLSX Dateien mit den dazugehörigen Metadaten bereitgeste
 
 Die Fotos wurden inzwischen auch auf Wiki commons hochgeladen und werden von dort auch referenziert
 
-Neben der Hauptanwendung (Karte mit geolokalisierten Fotos) gibt es noch ein [Spiel](http://damals.in/leipzig/spiel/) bei dem man den Aufnahmeort eines Fotos möglichst nah erraten soll sowie ein [Quiz](http://damals.in/leipzig/quiz/) bezogen auf die Fotos (bzw. ihrer dargestellten Orte / Elemente)
+Neben der Hauptanwendung (Karte mit geolokalisierten Fotos) gibt es noch ein [Spiel](http://damals.codeforleipzig.de/leipzig/spiel/) bei dem man den Aufnahmeort eines Fotos möglichst nah erraten soll sowie ein [Quiz](http://damals.codeforleipzig.de/leipzig/quiz/) bezogen auf die Fotos (bzw. ihrer dargestellten Orte / Elemente)
 
 ## Erweiterungsideen
  * Mehr freie Fotos auch aus unterschiedlichen Epochen geolokalisieren und referenzieren

--- a/content/projekte/2023-03-29-le-intelligentes-rathaus.md
+++ b/content/projekte/2023-03-29-le-intelligentes-rathaus.md
@@ -22,7 +22,7 @@ collaborators:
   links:
   - url: https://github.com/ErikOrtmann
     name: github
-- name: Lisa-Marie Steckel
+- name: Lisa Marie Steckel
   links:
   - url: https://github.com/vrifox
     name: github


### PR DESCRIPTION
fixes name of project member, switches domain of damals.in to my owned domain codeforleipzig.de 