### PR TITLE
update code of conduct

### DIFF
--- a/content/grundsaetze.md
+++ b/content/grundsaetze.md
@@ -13,7 +13,7 @@ Grundsätze
 {{< paragraph-center  >}}
 ## Mission Statement
 
-Code for Germany ist ein Netzwerk von ehrenamtlich engagierten Menschen, die sich für eine gemeinwohlorientierte digitale Zukunft einsetzen. Wir setzen uns mit dem Stand der Digitalisierung in unserer Stadt, Kommune und Region auseinander. Wir bauen hilfreiche Soft- und Hardware-Projekte. Wir analysieren aktuelle technologische Entwicklungen nach ihrem Nutzen für die Gesellschaft. Wir zeigen den Wert von Offenen Daten und leisten Überzeugungsarbeit für eine nachhaltige Digitalisierung der Verwaltung. 
+Code For Germany ist ein Netzwerk von Gruppen ehrenamtlich engagierter Freiwilliger, die ihre Fähigkeiten nutzen, um ihre Städte und das gesellschaftliche Miteinander positiv zu gestalten. Sie setzen sich für mehr Transparenz, Offene Daten und Partizipation in ihren Städten ein. Sie vermitteln insbesondere zwischen Zivilgesellschaft, Verwaltung und Politik und nutzen ihre Fähigkeiten, um die Kommunikation zwischen diesen zu verbessern und notwendige Impulse zu setzen, damit die Möglichkeiten der offenen und freien Digitalisierung so vielen Menschen wie möglich zugute kommen.
 
 ## Vision
 

--- a/content/grundsaetze.md
+++ b/content/grundsaetze.md
@@ -13,37 +13,28 @@ Grundsätze
 {{< paragraph-center  >}}
 ## Mission Statement
 
-Code For Germany ist ein Netzwerk von Gruppen ehrenamtlich engagierter Freiwilliger, die ihre Fähigkeiten nutzen, um ihre Städte und das gesellschaftliche Miteinander positiv zu gestalten. Sie setzen sich für mehr Transparenz, Offene Daten und Partizipation in ihren Städten ein. Sie vermitteln insbesondere zwischen Zivilgesellschaft, Verwaltung und Politik und nutzen ihre Fähigkeiten, um die Kommunikation zwischen diesen zu verbessern und notwendige Impulse zu setzen, damit die Möglichkeiten der offenen und freien Digitalisierung so vielen Menschen wie möglich zugute kommen.
+Code for Germany ist ein Netzwerk von ehrenamtlich engagierten Menschen, die sich für eine gemeinwohlorientierte digitale Zukunft einsetzen. Wir setzen uns mit dem Stand der Digitalisierung in unserer Stadt, Kommune und Region auseinander. Wir bauen hilfreiche Soft- und Hardware-Projekte. Wir analysieren aktuelle technologische Entwicklungen nach ihrem Nutzen für die Gesellschaft. Wir zeigen den Wert von Offenen Daten und leisten Überzeugungsarbeit für eine nachhaltige Digitalisierung der Verwaltung. 
 
+## Vision
 
-### 1. Präambel
+Wir wünschen uns eine offene Gesellschaft, in der Wissen frei zugänglich ist und geteilt wird. Wir engagieren uns für Offene Daten, Offenes Regierungshandeln, Open Source und Informationsfreiheit. Wir fordern eine gemeinwohlorientierte Digitalpolitik und ökologische Nachhaltigkeit von Soft- und Hardware. 
 
-Code for Germany ist ein Projekt der Open Knowledge Foundation Deutschland, in dem sich Gruppen ehrenamtlicher Freiwilliger in lokalen Labs engagieren. Mit diesem Code of Conduct regeln wir die wesentlichen Grundsätze für das Arbeiten und für Kooperationen im Rahmen des Code for Germany Netzwerks. Diese dienen als Leitsätze für das Verhalten untereinander sowie das Auftreten nach außen. Die Veranstaltungen der regionalen Code for Germany Gruppen sind grundsätzlich offen. Wer daran teilnimmt, über die Kommunikationskanäle kommuniziert und/oder anderweitig als Teil des Code-for-Germany-Netzwerks in Erscheinung tritt, erkennt diesen Code of Conduct als verbindlich an.
+## Organisation
 
-### 2. Organisation der Labs
+Die ehrenamtlich engagierten Menschen im Netzwerk Code for Germany organisieren sich in regionalen Gruppen, die sich regelmäßig online und in lokalen OK Labs, kurz für Open Knowledge Labs, treffen.   
+  
+Code for Germany hat sein rechtliches Zuhause bei dem gemeinnützigen Verein Open Knowledge Foundation Deutschland. Das Team der Open Knowledge Foundation Deutschland kann als Sprachrohr für die Anliegen des Netzwerks agieren, tritt aber nicht im Namen des Netzwerks auf. 
 
-Die Lab Leads organisieren und entwickeln die Labs in ihren Städten. Sie organisieren Veranstaltungen, indem sie sich um Räumlichkeiten und Einladungen kümmern. Sie unterstützen dabei eine örtliche Community in ihren Labs aufzubauen, indem sie Interessierte ansprechen und einladen und eine Atmosphäre schaffen, die einladend für neue Teilnehmenden ist. Sie sind primäre Ansprechpartner\*innen für die lokale Community und für die Open Knowledge Foundation. Lab Leads werden innerhalb der Labs bestimmt, dies kann per Wahl oder nach Konsensprinzip auf einem Lab Treffen erfolgen. Dies muss aber zuvor über die internen Kanäle mindestens zwei Wochen vorher angekündigt werden. Es sollte mindestens zwei Lab Leads geben, die sich gegenseitig vertreten und die Aufgaben teilen. Die Code For Labs und ihre Teilnehmenden sprechen und handeln in eigenem Namen. Ein Verweis auf die Open Knowledge Foundation und Code for Germany ist ausdrücklich erwünscht.
+Die Menschen in den Labs sind für die Organisation ihres Labs und ihrer Veranstaltungen verantwortlich. Die Labs und ihre Teilnehmer\*innen sprechen und handeln in ihrem eigenem Namen.
 
-Die Lab Leads sind für die Organisation des Labs und der Veranstaltungen verantwortlich. Sie sind Ansprechpartner oder Ansprechpartnerinnen für ihr Lab und für die Projektleitung von Code for Germany. Die OK Labs und ihre Teilnehmenden sprechen und handeln in eigenem Namen. Ein Verweis auf die Open Knowledge Foundation und Code for Germany ist ausdrücklich erwünscht.
+## Code of Conduct
 
-Für die Gründung eines neuen Labs wird zunächst die Open Knowledge Foundation (community@codefor.de) kontaktiert. In gemeinsamen Gesprächen wird evaluiert, ob eine Gründung infrage kommt und für beide Seiten sinnvoll ist. Die Projektleitung konsultiert hierfür auch den Community Rat. Bei positiver Entscheidung wird das neue Lab von Seiten der OKF bei der Ansprache möglicher Interessent\*innen und strategischer Partner\*innen in der Organisation einer Auftaktveranstaltung unterstützt.
+Bei Code for Germany gilt der [Code of Conduct (Verhaltenskodex) der Open Knowledge Foundation Deutschland](https://okfn.de/codeofconduct/).
 
-### 3. Repräsentation und Community Rat
-
-Für die bessere übergreifende Organisation der Labs untereinander und der Zusammenarbeit mit der OKF, wählt die Community einen “Rat”. Dieser besteht aus bis zu 5 Menschen und wird für ein Jahr gewählt. Wahlberechtigt sind alle Mitglieder aus den Labs die sich bis einer Woche vor Wahlbeginn auf der Code For Germany Mailingliste registriert haben. Mit der Wahl sprechen die Labs dem Beirat ihr ausdrückliches Vertrauen aus und wählen sie als Vertreter\*innen der Interessen der Labs.
-
-Der Community Rat ist ein gewähltes Gremium aus Vertreter\*innen der Labs, das von der Projektleitung für strategische Entscheidungen konsultiert wird. Der Rat unterstützt die Projektleitung bei der Planung und Erstellung von Strategien für Wachstum, Kommunikation, inhaltlicher Ausrichtung, etc., indem es die Perspektive und Bedürfnisse der Labs vertritt und so die Entwicklung des Programms mit gestaltet. Der Rat wird als offizielles Gremium auf der Seite von Code for Germany aufgeführt.
-
-### 4. Entscheidungsfindung
-
-Die Code for Germany Community strebt danach, Entscheidungen im Konsens zu treffen. Hierfür wird bei wichtigen Entscheidungen, welche das Programm oder eine öffentliche Stellungnahme betreffen, die Community konsultiert. Informationen und Optionen werden dafür verständlich aufbereitet und das Feedback der Community in einer Konsultationsphase von mindestens einer Woche eingeholt. Sollte eine schnellere Absprache nötig sein, können Entscheidungen in Rücksprache mit dem Community Rat getroffen werden.
-
-### 5. Verhalten untereinander
-
-Innerhalb des Netzwerks Code for Germany wollen wir erreichen, dass sich Menschen unabhängig von Geschlecht, sexueller Orientierung, Herkunft, Glauben, Aussehen, Religion oder Alter einbringen und wohlfühlen können. Wir dulden keine sexistischen, rassistischen, homo- oder transfeindlichen, ableistischen oder anderweitig marginalisierte Gruppen diskriminierenden Äußerungen – auch nicht, wenn sie „nur als Witz“ gedacht waren.
-
-Die Lab Leads sind für die Einhaltung des Code of Conducts verantwortlich und sorgen entsprechend dafür, dass eine Umgebung geschaffen wird, die einen respektvollen Umgang miteinander ermöglicht. Interessierte sind gerne willkommen.
-
-In Konfliktfällen und bei Verstößen gegen den Code of Conduct, wird innerhalb des Labs an einer Lösung gearbeitet, sollte dies nicht zu einer Lösung führen, kontaktieren die Teilnehmenden den Community Rat und die Projektleitung. Diese beraten gemeinsam über die weitere Vorgehensweise. Ziel für uns ist es, Konflikte durch Schlichtung zu lösen. Bei fehlgeschlagener Streitschlichtung und anhaltenden Verstößen kann durch die Projektleitung bei der Open Knowledge Foundation Deutschland, nach vorheriger Konsultation des Community Rats, der Ausschluss einer Person vom entsprechenden Lab und dem Code for Germany Netzwerk und deren Treffen beschlossen werden. Auch Lab Leads und Community Ratsmitglieder können von diesem Ausschluss betroffen sein.
+Der Code of Conduct regelt das Verhalten untereinander im Netzwerk Code for Germany sowie das Auftreten nach außen der Menschen, die sich im Rahmen von Code for Germany engagieren. Wer an Angeboten des Netzwerks teilnimmt, über die Kommunikationskanäle kommuniziert und/oder anderweitig als Teil des Code-for-Germany-Netzwerks in Erscheinung tritt, erkennt diesen Code of Conduct als verbindlich an. 
+  
+Die Organisator\*innen in den Labs, vor Ort und online, sind für die Einhaltung des Code of Conducts verantwortlich und sorgen entsprechend dafür, dass eine Umgebung geschaffen wird, die einen respektvollen Umgang miteinander ermöglicht.   
+  
+Labs können ihren eigenen Code of Conduct haben, der darf jedoch nicht weniger Schutz bieten als der [Code of Conduct der Open Knowledge Foundation](https://okfn.de/codeofconduct/). 
 
 {{< /paragraph-center  >}}


### PR DESCRIPTION
* Changed copy to reflect the changes agreed in the community call on 22 January 2026 
* Linked Code of Conduct from OKF, which is fairly new from 2024 and covers a lot that was missing before.
If the labs have their own code of conduct: this is specifically mentioned as an option. 